### PR TITLE
Update Frontegg AdminPortal to 5.78.0

### DIFF
--- a/libs/nextjs/package.json
+++ b/libs/nextjs/package.json
@@ -2,8 +2,8 @@
   "name": "@frontegg/nextjs",
   "version": "5.5.0",
   "dependencies": {
-    "@frontegg/admin-portal": "5.76.0",
-    "@frontegg/react-hooks": "5.76.0",
+    "@frontegg/admin-portal": "5.77.0",
+    "@frontegg/react-hooks": "5.77.0",
     "jose": "^4.8.0",
     "iron-session": "^6.1.2",
     "http-proxy": "^1.18.1",

--- a/libs/nextjs/package.json
+++ b/libs/nextjs/package.json
@@ -2,8 +2,8 @@
   "name": "@frontegg/nextjs",
   "version": "5.5.0",
   "dependencies": {
-    "@frontegg/admin-portal": "5.74.1",
-    "@frontegg/react-hooks": "5.74.1",
+    "@frontegg/admin-portal": "5.75.0",
+    "@frontegg/react-hooks": "5.75.0",
     "jose": "^4.8.0",
     "iron-session": "^6.1.2",
     "http-proxy": "^1.18.1",

--- a/libs/nextjs/package.json
+++ b/libs/nextjs/package.json
@@ -2,8 +2,8 @@
   "name": "@frontegg/nextjs",
   "version": "5.5.0",
   "dependencies": {
-    "@frontegg/admin-portal": "5.74.0",
-    "@frontegg/react-hooks": "5.74.0",
+    "@frontegg/admin-portal": "5.74.1",
+    "@frontegg/react-hooks": "5.74.1",
     "jose": "^4.8.0",
     "iron-session": "^6.1.2",
     "http-proxy": "^1.18.1",

--- a/libs/nextjs/package.json
+++ b/libs/nextjs/package.json
@@ -2,8 +2,8 @@
   "name": "@frontegg/nextjs",
   "version": "5.5.0",
   "dependencies": {
-    "@frontegg/admin-portal": "5.77.0",
-    "@frontegg/react-hooks": "5.77.0",
+    "@frontegg/admin-portal": "5.78.0",
+    "@frontegg/react-hooks": "5.78.0",
     "jose": "^4.8.0",
     "iron-session": "^6.1.2",
     "http-proxy": "^1.18.1",

--- a/libs/nextjs/package.json
+++ b/libs/nextjs/package.json
@@ -2,8 +2,8 @@
   "name": "@frontegg/nextjs",
   "version": "5.5.0",
   "dependencies": {
-    "@frontegg/admin-portal": "5.75.0",
-    "@frontegg/react-hooks": "5.75.0",
+    "@frontegg/admin-portal": "5.76.0",
+    "@frontegg/react-hooks": "5.76.0",
     "jose": "^4.8.0",
     "iron-session": "^6.1.2",
     "http-proxy": "^1.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1098,44 +1098,44 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@frontegg/admin-portal@5.76.0":
-  version "5.76.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.76.0.tgz#4a42aac1f62848e761ffbbda5f4e760c66a3f60f"
-  integrity sha512-YH0ckkkvTvvLONqqMsRIs9hIOQBfqwU9/faIrcAzCwVdMDajHTcVqOXO7BxE3rEjdaOPXM7c32Y/TFGtHE7gDg==
+"@frontegg/admin-portal@5.77.0":
+  version "5.77.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.77.0.tgz#a7096bc459d12ed747446e8251c1e53f951c8810"
+  integrity sha512-tC0xO2FEju7Qaor2CS6s2qzyd+0nlt5s827DeppFWoZMAjE1iBDVDyk99kfrjWVOgVOJOdAMGCmlyvRUjyXiJQ==
   dependencies:
-    "@frontegg/types" "5.76.0"
+    "@frontegg/types" "5.77.0"
     uuid "^8.3.2"
 
-"@frontegg/react-hooks@5.76.0":
-  version "5.76.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.76.0.tgz#9d1e1e51381aca63dd1d42b8860cf7e20b55cea5"
-  integrity sha512-G0hExANORe5k9JB0MkVRqc8bV71fD7u7hJDwFz7FVqwt/1TqoTbaToPOINRBoL76wQZ0tQOlc+ptPzdlfu3xsg==
+"@frontegg/react-hooks@5.77.0":
+  version "5.77.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.77.0.tgz#9ed72994f486ffe80ce7d7c3e3fbe17fb36da34d"
+  integrity sha512-GOrmrdP4sphS/1Qz/ViHbfm6faM3CgRoTe0gbPQ+NUmUXONzhjS7RjNRQKZ3RgWEek6HOVRTT2wKF1kN0DOUQQ==
   dependencies:
-    "@frontegg/redux-store" "5.76.0"
+    "@frontegg/redux-store" "5.77.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@5.76.0":
-  version "5.76.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.76.0.tgz#9de6d4b832e90c69ab1d424044c896ae70762836"
-  integrity sha512-eUR+jmJyuZdI9VKalpIvHVAf+GuM3sKlvPR9GHJKDTVxr2ibO9oY1n94IIjy3k/ULziHSPGB/KecX7L6lPNJsg==
+"@frontegg/redux-store@5.77.0":
+  version "5.77.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.77.0.tgz#870a6f3951f1134b22cf9745afbb7f6a530814e6"
+  integrity sha512-VY5bXvyjZOwBCKagsMe/fqfHAyv7pbMXuonJ7wfrMAWTcF6WHOqJJZjLBnlD6k5Fa7vLsiuZqOqHUSPQvzrNJg==
   dependencies:
-    "@frontegg/rest-api" "^3.0.10"
+    "@frontegg/rest-api" "^3.0.11"
     "@reduxjs/toolkit" "^1.5.0"
     redux-saga "^1.1.0"
     tslib "^2.3.1"
     uuid "^8.3.0"
 
-"@frontegg/rest-api@^3.0.10":
-  version "3.0.10"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.10.tgz#043bb0cc2b8387c2243bdbbb4a0bef71929d1e1c"
-  integrity sha512-Ho3bjTP0uJlknge+GFCoBnZNTBJUbmSINbTw5d5FUpql5XXP6vEVGi4qU3HomFmqUeyvDyLsTNbbZw84kv9+Lg==
+"@frontegg/rest-api@^3.0.11":
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.11.tgz#69aa672cc4e745985e78a5067239d91068ac5a21"
+  integrity sha512-GHFG8fNvpP0uYxJvpj1ZKN4qyCqPf8hnkcoSmdebttNqXv2j+/I8iNeDGrDUlflNoWMFImq0Lw6wTGy3Y+4Pbw==
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@5.76.0":
-  version "5.76.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.76.0.tgz#e9820fe8944ef78592eea5d0f573ebfb814a63e6"
-  integrity sha512-3KyfKJl/uEaU0Z3IpaHH3Kufw3bflj8dzRM6VO8S8m8LKV9fDbzv9JtxnWZx1IsGmGS/qPZfVJSRnzeS+uSu6A==
+"@frontegg/types@5.77.0":
+  version "5.77.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.77.0.tgz#c59c2cc6e8f6b2d2aaa57e52f2e260be545b9729"
+  integrity sha512-+WRkkgdjjipxA4JU0ZvYja2sc5sZkpUWJHeLFLJDeCmz33TUl+mKQQP9kdQepAULZWUFBoeZio1s0F/J/US2Dw==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1098,26 +1098,26 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@frontegg/admin-portal@5.77.0":
-  version "5.77.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.77.0.tgz#a7096bc459d12ed747446e8251c1e53f951c8810"
-  integrity sha512-tC0xO2FEju7Qaor2CS6s2qzyd+0nlt5s827DeppFWoZMAjE1iBDVDyk99kfrjWVOgVOJOdAMGCmlyvRUjyXiJQ==
+"@frontegg/admin-portal@5.78.0":
+  version "5.78.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.78.0.tgz#97dd0464904f819d7d29396afee61bc57dbd303b"
+  integrity sha512-S55/imkQCkHLRxrXweZ3a2NuYCFLi4hIxvWKH8Aa1I9rOWmJYHQKitS/DNxmPEuxRyQwQW5oJ6dH/ZjoqYMQSQ==
   dependencies:
-    "@frontegg/types" "5.77.0"
+    "@frontegg/types" "5.78.0"
     uuid "^8.3.2"
 
-"@frontegg/react-hooks@5.77.0":
-  version "5.77.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.77.0.tgz#9ed72994f486ffe80ce7d7c3e3fbe17fb36da34d"
-  integrity sha512-GOrmrdP4sphS/1Qz/ViHbfm6faM3CgRoTe0gbPQ+NUmUXONzhjS7RjNRQKZ3RgWEek6HOVRTT2wKF1kN0DOUQQ==
+"@frontegg/react-hooks@5.78.0":
+  version "5.78.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.78.0.tgz#5f9f9452490a29a14569d816cbd6d46934446423"
+  integrity sha512-K1r98uKC8K44km59hwpqHqNwfc7AQ5FNAnT6ULYvfoORbC1leihoZgMseI42KjNWp7nKGcZn1XXj0m3ZLeAgig==
   dependencies:
-    "@frontegg/redux-store" "5.77.0"
+    "@frontegg/redux-store" "5.78.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@5.77.0":
-  version "5.77.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.77.0.tgz#870a6f3951f1134b22cf9745afbb7f6a530814e6"
-  integrity sha512-VY5bXvyjZOwBCKagsMe/fqfHAyv7pbMXuonJ7wfrMAWTcF6WHOqJJZjLBnlD6k5Fa7vLsiuZqOqHUSPQvzrNJg==
+"@frontegg/redux-store@5.78.0":
+  version "5.78.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.78.0.tgz#0287d17aaad2caae5447f7498c85bd15eac8b093"
+  integrity sha512-PqMGGUQNQFpP0aL/1E0elbeog3CBXHVKYvIwJVLS7f8OTCowqQDIBATmZueyi2E+EkU584gJ77pn294x6xEIjQ==
   dependencies:
     "@frontegg/rest-api" "^3.0.11"
     "@reduxjs/toolkit" "^1.5.0"
@@ -1132,10 +1132,10 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@5.77.0":
-  version "5.77.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.77.0.tgz#c59c2cc6e8f6b2d2aaa57e52f2e260be545b9729"
-  integrity sha512-+WRkkgdjjipxA4JU0ZvYja2sc5sZkpUWJHeLFLJDeCmz33TUl+mKQQP9kdQepAULZWUFBoeZio1s0F/J/US2Dw==
+"@frontegg/types@5.78.0":
+  version "5.78.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.78.0.tgz#748aa9fa66d9aff21d400023aad6fd321f532089"
+  integrity sha512-H+k/u3RtXgcl0U5nUYHFCxGsGtermQVSkHX5xepTsCwEhlL7nf/KH4pzngTcKSoerSTkrc1QpO/ccMM/Et1Hqw==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1098,26 +1098,26 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@frontegg/admin-portal@5.74.1":
-  version "5.74.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.74.1.tgz#cf8fb7ca5695b16b322749904670abce8bfee63a"
-  integrity sha512-pK8hfuf9jSmDZa3u4JvGxhrAf2rKRdJB4lBOgDebKEk4o8maIQ99zEEU30GD0OLE+hWfr+Uit9vdut5NKVBTAQ==
+"@frontegg/admin-portal@5.75.0":
+  version "5.75.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.75.0.tgz#b3aacd6bb7d9f6eaecc10ca35aa71328eb570d1c"
+  integrity sha512-QzTbcB3JnBdldIar+5NxJPy/mz033bLUZINO8/ruFHUev8RDUEoW5/ar2YlRRqHqQr0937Xcb8ZiqcUMMY3euQ==
   dependencies:
-    "@frontegg/types" "5.74.1"
+    "@frontegg/types" "5.75.0"
     uuid "^8.3.2"
 
-"@frontegg/react-hooks@5.74.1":
-  version "5.74.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.74.1.tgz#9905a8a5a2336f7f9e4c62e65ca2ad96ab2173b5"
-  integrity sha512-zpTMtrl9sQCqLiWTgX56bQ8SGYb0K/YzimxPnuMhQqj+ZTfhizK5ZETF7bvYZVi4oqrJH5ux/cW+iMMPfwTJ4A==
+"@frontegg/react-hooks@5.75.0":
+  version "5.75.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.75.0.tgz#2edc2b035a6f7ff331df2808ea56d419a5bf7ec3"
+  integrity sha512-ilUucRiJ24qRNEPQ81rZFFDWq5xuvMkffuV+Y5seEhMKOqKWvuZi7vSd+3nWf/qCVpMR4vpbPcrF04Khcglpuw==
   dependencies:
-    "@frontegg/redux-store" "5.74.1"
+    "@frontegg/redux-store" "5.75.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@5.74.1":
-  version "5.74.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.74.1.tgz#053e9acd366af95bb418cc34e7337c705ba8cc68"
-  integrity sha512-Cvfd5jq81Kgr8JuU4MJv7cfA1rL5HNPm+3uX8V5zdsb2w0eppKEyv6UaZ2HrMZ3oMQj3B7BoFjG/pqqR5BqK7A==
+"@frontegg/redux-store@5.75.0":
+  version "5.75.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.75.0.tgz#725b8453c74866e59c83a0a9515340cea6021624"
+  integrity sha512-Lum3UlAvM/jCOZzDjZsbw+Hmo9zsdpOKCUSs8HwEMTCs7T889JKRJxn6XcqljHTyCGb7Hg1xdEDuWN2p8cfJEQ==
   dependencies:
     "@frontegg/rest-api" "^3.0.10"
     "@reduxjs/toolkit" "^1.5.0"
@@ -1132,10 +1132,10 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@5.74.1":
-  version "5.74.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.74.1.tgz#5782bf851aae250797130bd6bea15ef020183a1a"
-  integrity sha512-e0THoWjjnyzP+8KU8VDzBlet5tZk8Sn0ZDTwjzNerjzWMA1YNoubgtmRxE74LrGCRKus1BjBNb/EWxeyCajzSA==
+"@frontegg/types@5.75.0":
+  version "5.75.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.75.0.tgz#47a405c731139f44bab986c8692cc2b3b2291fc7"
+  integrity sha512-lTDF7H/nnhVW1FGiaipJ+DlWTcswWhpej86OiLr55qJ0vgJyjiQ5dZYFdVKF57sYGAiIL2G75+9s+5tlypMpGA==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1098,26 +1098,26 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@frontegg/admin-portal@5.74.0":
-  version "5.74.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.74.0.tgz#b8f75788b80e56f1cc560c4fe3164f3d8a11ec80"
-  integrity sha512-6vhH2AYjjXxEVGIF3+ysf5kzP3LXttW/Z06sWTbybqcaLIHuKOIbx5aZxh7HQaFMMB+8TlZAS2xGzRV8y21hbw==
+"@frontegg/admin-portal@5.74.1":
+  version "5.74.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.74.1.tgz#cf8fb7ca5695b16b322749904670abce8bfee63a"
+  integrity sha512-pK8hfuf9jSmDZa3u4JvGxhrAf2rKRdJB4lBOgDebKEk4o8maIQ99zEEU30GD0OLE+hWfr+Uit9vdut5NKVBTAQ==
   dependencies:
-    "@frontegg/types" "5.74.0"
+    "@frontegg/types" "5.74.1"
     uuid "^8.3.2"
 
-"@frontegg/react-hooks@5.74.0":
-  version "5.74.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.74.0.tgz#03b11447c7795332ea60d7b07d3a9f54e1e006ec"
-  integrity sha512-NhqgNZEUXi1gPF8ruBVfZ11YsTIy03m0v7RjkhknZVBtoQwp2jgVaCk0DyB+a0kjPr0Gp9OLj/nuwvmnRh/VTQ==
+"@frontegg/react-hooks@5.74.1":
+  version "5.74.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.74.1.tgz#9905a8a5a2336f7f9e4c62e65ca2ad96ab2173b5"
+  integrity sha512-zpTMtrl9sQCqLiWTgX56bQ8SGYb0K/YzimxPnuMhQqj+ZTfhizK5ZETF7bvYZVi4oqrJH5ux/cW+iMMPfwTJ4A==
   dependencies:
-    "@frontegg/redux-store" "5.74.0"
+    "@frontegg/redux-store" "5.74.1"
     react-redux "^7.x"
 
-"@frontegg/redux-store@5.74.0":
-  version "5.74.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.74.0.tgz#3451d2f63494c2b03a513cbceed896e40195d4da"
-  integrity sha512-GMQTNjTjbx1LWRD2iHaC/wDruDPd7DFGVrStYRXEQAFuL27/R+CIL5eVARXDY6P+YT7SM+PCAwjyaWHKs4kmAw==
+"@frontegg/redux-store@5.74.1":
+  version "5.74.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.74.1.tgz#053e9acd366af95bb418cc34e7337c705ba8cc68"
+  integrity sha512-Cvfd5jq81Kgr8JuU4MJv7cfA1rL5HNPm+3uX8V5zdsb2w0eppKEyv6UaZ2HrMZ3oMQj3B7BoFjG/pqqR5BqK7A==
   dependencies:
     "@frontegg/rest-api" "^3.0.10"
     "@reduxjs/toolkit" "^1.5.0"
@@ -1132,10 +1132,10 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@5.74.0":
-  version "5.74.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.74.0.tgz#546f87c40bb646af5117d232a6639a7b9c29655d"
-  integrity sha512-gAWb/e3iL27zlZ7+Pmt89sJYr1dS6nsfpcI83Ml9AdGyNikK4SDrnkUzqU1okPaT3lIR9kvxRen3aURFu6chWA==
+"@frontegg/types@5.74.1":
+  version "5.74.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.74.1.tgz#5782bf851aae250797130bd6bea15ef020183a1a"
+  integrity sha512-e0THoWjjnyzP+8KU8VDzBlet5tZk8Sn0ZDTwjzNerjzWMA1YNoubgtmRxE74LrGCRKus1BjBNb/EWxeyCajzSA==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1098,26 +1098,26 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@frontegg/admin-portal@5.75.0":
-  version "5.75.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.75.0.tgz#b3aacd6bb7d9f6eaecc10ca35aa71328eb570d1c"
-  integrity sha512-QzTbcB3JnBdldIar+5NxJPy/mz033bLUZINO8/ruFHUev8RDUEoW5/ar2YlRRqHqQr0937Xcb8ZiqcUMMY3euQ==
+"@frontegg/admin-portal@5.76.0":
+  version "5.76.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.76.0.tgz#4a42aac1f62848e761ffbbda5f4e760c66a3f60f"
+  integrity sha512-YH0ckkkvTvvLONqqMsRIs9hIOQBfqwU9/faIrcAzCwVdMDajHTcVqOXO7BxE3rEjdaOPXM7c32Y/TFGtHE7gDg==
   dependencies:
-    "@frontegg/types" "5.75.0"
+    "@frontegg/types" "5.76.0"
     uuid "^8.3.2"
 
-"@frontegg/react-hooks@5.75.0":
-  version "5.75.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.75.0.tgz#2edc2b035a6f7ff331df2808ea56d419a5bf7ec3"
-  integrity sha512-ilUucRiJ24qRNEPQ81rZFFDWq5xuvMkffuV+Y5seEhMKOqKWvuZi7vSd+3nWf/qCVpMR4vpbPcrF04Khcglpuw==
+"@frontegg/react-hooks@5.76.0":
+  version "5.76.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.76.0.tgz#9d1e1e51381aca63dd1d42b8860cf7e20b55cea5"
+  integrity sha512-G0hExANORe5k9JB0MkVRqc8bV71fD7u7hJDwFz7FVqwt/1TqoTbaToPOINRBoL76wQZ0tQOlc+ptPzdlfu3xsg==
   dependencies:
-    "@frontegg/redux-store" "5.75.0"
+    "@frontegg/redux-store" "5.76.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@5.75.0":
-  version "5.75.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.75.0.tgz#725b8453c74866e59c83a0a9515340cea6021624"
-  integrity sha512-Lum3UlAvM/jCOZzDjZsbw+Hmo9zsdpOKCUSs8HwEMTCs7T889JKRJxn6XcqljHTyCGb7Hg1xdEDuWN2p8cfJEQ==
+"@frontegg/redux-store@5.76.0":
+  version "5.76.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.76.0.tgz#9de6d4b832e90c69ab1d424044c896ae70762836"
+  integrity sha512-eUR+jmJyuZdI9VKalpIvHVAf+GuM3sKlvPR9GHJKDTVxr2ibO9oY1n94IIjy3k/ULziHSPGB/KecX7L6lPNJsg==
   dependencies:
     "@frontegg/rest-api" "^3.0.10"
     "@reduxjs/toolkit" "^1.5.0"
@@ -1132,10 +1132,10 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@5.75.0":
-  version "5.75.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.75.0.tgz#47a405c731139f44bab986c8692cc2b3b2291fc7"
-  integrity sha512-lTDF7H/nnhVW1FGiaipJ+DlWTcswWhpej86OiLr55qJ0vgJyjiQ5dZYFdVKF57sYGAiIL2G75+9s+5tlypMpGA==
+"@frontegg/types@5.76.0":
+  version "5.76.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.76.0.tgz#e9820fe8944ef78592eea5d0f573ebfb814a63e6"
+  integrity sha512-3KyfKJl/uEaU0Z3IpaHH3Kufw3bflj8dzRM6VO8S8m8LKV9fDbzv9JtxnWZx1IsGmGS/qPZfVJSRnzeS+uSu6A==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 5.78.0:
- [FR-0000](https://frontegg.atlassian.net/browse/FR-0000) - session management hotfix - [0120fefe](https://github.com/frontegg/admin-box/pulls?q=0120fefe)

### AdminPortal 5.77.0:
- [FR-8738](https://frontegg.atlassian.net/browse/FR-8738) - Update CODEOWNERS to all developers writing in admin box - [8ce8c5a9](https://github.com/frontegg/admin-box/pulls?q=8ce8c5a9)
- [FR-8679](https://frontegg.atlassian.net/browse/FR-8679) - fix pii data on local storage - [372fe746](https://github.com/frontegg/admin-box/pulls?q=372fe746)

### AdminPortal 5.76.0:
- [FR-8652](https://frontegg.atlassian.net/browse/FR-8652) - added support for additional params on hosted login - [49000139](https://github.com/frontegg/admin-box/pulls?q=49000139)
- [FR-8477](https://frontegg.atlassian.net/browse/FR-8477) - disclaimer checkbox change formik implementation - [d174eef3](https://github.com/frontegg/admin-box/pulls?q=d174eef3)
- [FR-8355](https://frontegg.atlassian.net/browse/FR-8355) - fixed mfaRememberThisDevice text - [84175713](https://github.com/frontegg/admin-box/pulls?q=84175713)

### AdminPortal 5.75.0:
- [FR-8562](https://frontegg.atlassian.net/browse/FR-8562) - Bump eventsource from 1.0.7 to 1.1.2 - [d356308c](https://github.com/frontegg/admin-box/pulls?q=d356308c)

### AdminPortal 5.74.1:
- [FR-8560](https://frontegg.atlassian.net/browse/FR-8560) - Bump jsdom from 16.4.0 to 16.7.0 - [4cc3eaf8](https://github.com/frontegg/admin-box/pulls?q=4cc3eaf8)
- [FR-8559](https://frontegg.atlassian.net/browse/FR-8559) - Bump moment from 2.29.2 to 2.29.4 - [d26bd03d](https://github.com/frontegg/admin-box/pulls?q=d26bd03d)
- [FR-8378](https://frontegg.atlassian.net/browse/FR-8378) - Bump terser from 4.8.0 to 4.8.1 - [005b0961](https://github.com/frontegg/admin-box/pulls?q=005b0961)
- [FR-8355](https://frontegg.atlassian.net/browse/FR-8355) - added new - shorter text option for devices that remember mfa - [64e56c1a](https://github.com/frontegg/admin-box/pulls?q=64e56c1a)