### PR TITLE
Update Frontegg AdminPortal to 6.2.0

### DIFF
--- a/libs/nextjs/package.json
+++ b/libs/nextjs/package.json
@@ -3,7 +3,7 @@
   "version": "5.5.0",
   "dependencies": {
     "@frontegg/admin-portal": "5.80.2",
-    "@frontegg/react-hooks": "6.1.0",
+    "@frontegg/react-hooks": "6.2.0",
     "jose": "^4.8.0",
     "iron-session": "^6.1.2",
     "http-proxy": "^1.18.1",

--- a/libs/nextjs/package.json
+++ b/libs/nextjs/package.json
@@ -3,7 +3,7 @@
   "version": "5.5.0",
   "dependencies": {
     "@frontegg/admin-portal": "5.80.2",
-    "@frontegg/react-hooks": "5.80.2",
+    "@frontegg/react-hooks": "6.1.0",
     "jose": "^4.8.0",
     "iron-session": "^6.1.2",
     "http-proxy": "^1.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1106,21 +1106,21 @@
     "@frontegg/types" "5.80.2"
     uuid "^8.3.2"
 
-"@frontegg/react-hooks@6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.1.0.tgz#7dc77ea6b530d08751cbd5c598941fd8d7e2ee64"
-  integrity sha512-ZAuQwa57Pkq3UqPNe4q6YBx6gm/MSl1li+/4om543atiEiCc/Or05Zm1ZncWfGIDV46JDAUBd0Rokx7a45xWoA==
+"@frontegg/react-hooks@6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.2.0.tgz#679417c8510298516c10991496951233752ef6d8"
+  integrity sha512-jkdxVAdPcUJtt7gw5HBLebJFB00YzhC36VkLk3jWRbdx+C/Pxp/PyUXLbqJszLaoqqI4qJeRJsioWDVJ4zipBw==
   dependencies:
     "@babel/runtime" "^7.17.2"
-    "@frontegg/redux-store" "6.1.0"
-    "@frontegg/types" "6.1.0"
-    "@types/react" "^17.0.0 || ^18.0.0"
+    "@frontegg/redux-store" "6.2.0"
+    "@frontegg/types" "6.2.0"
+    "@types/react" "*"
     react-redux "^7.x"
 
-"@frontegg/redux-store@6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.1.0.tgz#e64af4783e5146e1cf499b41c7fcad4d0e5beaf9"
-  integrity sha512-4JBiV5NghLapdiJdhv8k0Lx3Cq7bVZOiypoqx607GIsDScaQ963dMS3gLtPbNPxCVgAdLp2cmkMUcRH3G8/ctA==
+"@frontegg/redux-store@6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.2.0.tgz#d030ec32ada7bb331926bc2c4b382cf9a35450d2"
+  integrity sha512-mHiHnfVcdxvsYXqu1gkjMka2jsBPWw9jX3tonba+znU82N29P+JDHB8necOEiaVSBjilAEPwQZ9VTFkiQpqVRg==
   dependencies:
     "@babel/runtime" "^7.17.2"
     "@frontegg/rest-api" "3.0.11"
@@ -1142,13 +1142,13 @@
   dependencies:
     csstype "^3.0.9"
 
-"@frontegg/types@6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.1.0.tgz#00e3123a2884e497dfdf32ffada94879ba0a27f0"
-  integrity sha512-dUv5CYdKpbpnDv2Xdtkzh/QpZRONwY0Z+dbuvcwJDPC9Wa2SjtUZOjxhx28CeSzFnLCTTTTxc2gfaAsm6/5gIg==
+"@frontegg/types@6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.2.0.tgz#a2d3c18a967cd438058852bf77238893d42316c2"
+  integrity sha512-R+i61fhUc9Kk1FmQ4oVSnTg2XqcSWZHnQ1cJk8qfdNOasHP/F9xGd00Z5iAgdL05trM2DHMtFAJEa51gMtZHYQ==
   dependencies:
     "@babel/runtime" "^7.17.2"
-    "@frontegg/redux-store" "6.1.0"
+    "@frontegg/redux-store" "6.2.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 
@@ -2643,15 +2643,6 @@
   version "18.0.1"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.1.tgz#1b2e02fb7613212518733946e49fb963dfc66e19"
   integrity sha512-VnWlrVgG0dYt+NqlfMI0yUYb8Rdl4XUROyH+c6gq/iFCiZ805Vi//26UW38DHnxQkbDhnrIWTBiy6oKZqL11cw==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^17.0.0 || ^18.0.0":
-  version "18.0.18"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.18.tgz#9f16f33d57bc5d9dca848d12c3572110ff9429ac"
-  integrity sha512-6hI08umYs6NaiHFEEGioXnxJ+oEhY3eRz8VCUaudZmGdtvPviCJB8mgaMxaDWAdPSYd4eFavrPk2QIolwbLYrg==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1106,26 +1106,29 @@
     "@frontegg/types" "5.80.2"
     uuid "^8.3.2"
 
-"@frontegg/react-hooks@5.80.2":
-  version "5.80.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.80.2.tgz#e6a01f94f659c755ea75757cb061fdc4c433cebe"
-  integrity sha512-YndrOew/J+Z1gXUk/tHS1RW+0TymOHi7OqA706zrIltr4xb8ktL9ThMPpPTa2teKX4CzCW229Dab/kV33dqzMA==
+"@frontegg/react-hooks@6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.1.0.tgz#7dc77ea6b530d08751cbd5c598941fd8d7e2ee64"
+  integrity sha512-ZAuQwa57Pkq3UqPNe4q6YBx6gm/MSl1li+/4om543atiEiCc/Or05Zm1ZncWfGIDV46JDAUBd0Rokx7a45xWoA==
   dependencies:
-    "@frontegg/redux-store" "5.80.2"
+    "@babel/runtime" "^7.17.2"
+    "@frontegg/redux-store" "6.1.0"
+    "@frontegg/types" "6.1.0"
+    "@types/react" "^17.0.0 || ^18.0.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@5.80.2":
-  version "5.80.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.80.2.tgz#586b60946602fc49dc5ed505f6c033460fb87320"
-  integrity sha512-4SBBvYtzefntAsZkrNE5Bg2qZcfaTCnupmQnzWSJ6tshNuAdmNJCSkyIiYs/8AtyUmTkdlnTBTpHU2h6A7THLg==
+"@frontegg/redux-store@6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.1.0.tgz#e64af4783e5146e1cf499b41c7fcad4d0e5beaf9"
+  integrity sha512-4JBiV5NghLapdiJdhv8k0Lx3Cq7bVZOiypoqx607GIsDScaQ963dMS3gLtPbNPxCVgAdLp2cmkMUcRH3G8/ctA==
   dependencies:
-    "@frontegg/rest-api" "^3.0.11"
-    "@reduxjs/toolkit" "^1.5.0"
-    redux-saga "^1.1.0"
-    tslib "^2.3.1"
-    uuid "^8.3.0"
+    "@babel/runtime" "^7.17.2"
+    "@frontegg/rest-api" "3.0.11"
+    "@reduxjs/toolkit" "^1.8.3"
+    redux-saga "^1.1.3"
+    uuid "^8.3.2"
 
-"@frontegg/rest-api@^3.0.11":
+"@frontegg/rest-api@3.0.11":
   version "3.0.11"
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.11.tgz#69aa672cc4e745985e78a5067239d91068ac5a21"
   integrity sha512-GHFG8fNvpP0uYxJvpj1ZKN4qyCqPf8hnkcoSmdebttNqXv2j+/I8iNeDGrDUlflNoWMFImq0Lw6wTGy3Y+4Pbw==
@@ -1138,6 +1141,16 @@
   integrity sha512-JTv4mVAq9BNtNrS5HAK8krec7RbR8ZFEv8eqAKBPn2FXWQ/pgFg3yDEOVfcovr28wXzbM/S7kGhUPZruJVd5aw==
   dependencies:
     csstype "^3.0.9"
+
+"@frontegg/types@6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.1.0.tgz#00e3123a2884e497dfdf32ffada94879ba0a27f0"
+  integrity sha512-dUv5CYdKpbpnDv2Xdtkzh/QpZRONwY0Z+dbuvcwJDPC9Wa2SjtUZOjxhx28CeSzFnLCTTTTxc2gfaAsm6/5gIg==
+  dependencies:
+    "@babel/runtime" "^7.17.2"
+    "@frontegg/redux-store" "6.1.0"
+    csstype "^3.0.9"
+    deepmerge "^4.2.2"
 
 "@hapi/b64@5.x.x":
   version "5.0.0"
@@ -1842,54 +1855,54 @@
     schema-utils "^3.0.0"
     source-map "^0.7.3"
 
-"@redux-saga/core@^1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@redux-saga/core/-/core-1.1.3.tgz#3085097b57a4ea8db5528d58673f20ce0950f6a4"
-  integrity sha512-8tInBftak8TPzE6X13ABmEtRJGjtK17w7VUs7qV17S8hCO5S3+aUTWZ/DBsBJPdE8Z5jOPwYALyvofgq1Ws+kg==
+"@redux-saga/core@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@redux-saga/core/-/core-1.2.1.tgz#3680989621517d075a2cc85e0d2744b682990ed8"
+  integrity sha512-ABCxsZy9DwmNoYNo54ZlfuTvh77RXx8ODKpxOHeWam2dOaLGQ7vAktpfOtqSeTdYrKEORtTeWnxkGJMmPOoukg==
   dependencies:
     "@babel/runtime" "^7.6.3"
-    "@redux-saga/deferred" "^1.1.2"
-    "@redux-saga/delay-p" "^1.1.2"
-    "@redux-saga/is" "^1.1.2"
-    "@redux-saga/symbols" "^1.1.2"
-    "@redux-saga/types" "^1.1.0"
+    "@redux-saga/deferred" "^1.2.1"
+    "@redux-saga/delay-p" "^1.2.1"
+    "@redux-saga/is" "^1.1.3"
+    "@redux-saga/symbols" "^1.1.3"
+    "@redux-saga/types" "^1.2.1"
     redux "^4.0.4"
     typescript-tuple "^2.2.1"
 
-"@redux-saga/deferred@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@redux-saga/deferred/-/deferred-1.1.2.tgz#59937a0eba71fff289f1310233bc518117a71888"
-  integrity sha512-908rDLHFN2UUzt2jb4uOzj6afpjgJe3MjICaUNO3bvkV/kN/cNeI9PMr8BsFXB/MR8WTAZQq/PlTq8Kww3TBSQ==
+"@redux-saga/deferred@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@redux-saga/deferred/-/deferred-1.2.1.tgz#aca373a08ccafd6f3481037f2f7ee97f2c87c3ec"
+  integrity sha512-cmin3IuuzMdfQjA0lG4B+jX+9HdTgHZZ+6u3jRAOwGUxy77GSlTi4Qp2d6PM1PUoTmQUR5aijlA39scWWPF31g==
 
-"@redux-saga/delay-p@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@redux-saga/delay-p/-/delay-p-1.1.2.tgz#8f515f4b009b05b02a37a7c3d0ca9ddc157bb355"
-  integrity sha512-ojc+1IoC6OP65Ts5+ZHbEYdrohmIw1j9P7HS9MOJezqMYtCDgpkoqB5enAAZrNtnbSL6gVCWPHaoaTY5KeO0/g==
+"@redux-saga/delay-p@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@redux-saga/delay-p/-/delay-p-1.2.1.tgz#e72ac4731c5080a21f75b61bedc31cb639d9e446"
+  integrity sha512-MdiDxZdvb1m+Y0s4/hgdcAXntpUytr9g0hpcOO1XFVyyzkrDu3SKPgBFOtHn7lhu7n24ZKIAT1qtKyQjHqRd+w==
   dependencies:
-    "@redux-saga/symbols" "^1.1.2"
+    "@redux-saga/symbols" "^1.1.3"
 
-"@redux-saga/is@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@redux-saga/is/-/is-1.1.2.tgz#ae6c8421f58fcba80faf7cadb7d65b303b97e58e"
-  integrity sha512-OLbunKVsCVNTKEf2cH4TYyNbbPgvmZ52iaxBD4I1fTif4+MTXMa4/Z07L83zW/hTCXwpSZvXogqMqLfex2Tg6w==
+"@redux-saga/is@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@redux-saga/is/-/is-1.1.3.tgz#b333f31967e87e32b4e6b02c75b78d609dd4ad73"
+  integrity sha512-naXrkETG1jLRfVfhOx/ZdLj0EyAzHYbgJWkXbB3qFliPcHKiWbv/ULQryOAEKyjrhiclmr6AMdgsXFyx7/yE6Q==
   dependencies:
-    "@redux-saga/symbols" "^1.1.2"
-    "@redux-saga/types" "^1.1.0"
+    "@redux-saga/symbols" "^1.1.3"
+    "@redux-saga/types" "^1.2.1"
 
-"@redux-saga/symbols@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@redux-saga/symbols/-/symbols-1.1.2.tgz#216a672a487fc256872b8034835afc22a2d0595d"
-  integrity sha512-EfdGnF423glv3uMwLsGAtE6bg+R9MdqlHEzExnfagXPrIiuxwr3bdiAwz3gi+PsrQ3yBlaBpfGLtDG8rf3LgQQ==
+"@redux-saga/symbols@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@redux-saga/symbols/-/symbols-1.1.3.tgz#b731d56201719e96dc887dc3ae9016e761654367"
+  integrity sha512-hCx6ZvU4QAEUojETnX8EVg4ubNLBFl1Lps4j2tX7o45x/2qg37m3c6v+kSp8xjDJY+2tJw4QB3j8o8dsl1FDXg==
 
-"@redux-saga/types@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@redux-saga/types/-/types-1.1.0.tgz#0e81ce56b4883b4b2a3001ebe1ab298b84237204"
-  integrity sha512-afmTuJrylUU/0OtqzaRkbyYFFNgCF73Bvel/sw90pvGrWIZ+vyoIJqA6eMSoA6+nb443kTmulmBtC9NerXboNg==
+"@redux-saga/types@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@redux-saga/types/-/types-1.2.1.tgz#9403f51c17cae37edf870c6bc0c81c1ece5ccef8"
+  integrity sha512-1dgmkh+3so0+LlBWRhGA33ua4MYr7tUOj+a9Si28vUi0IUFNbff1T3sgpeDJI/LaC75bBYnQ0A3wXjn0OrRNBA==
 
-"@reduxjs/toolkit@^1.5.0":
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.8.1.tgz#94ee1981b8cf9227cda40163a04704a9544c9a9f"
-  integrity sha512-Q6mzbTpO9nOYRnkwpDlFOAbQnd3g7zj7CtHAZWz5SzE5lcV97Tf8f3SzOO8BoPOMYBFgfZaqTUZqgGu+a0+Fng==
+"@reduxjs/toolkit@^1.8.3":
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.8.5.tgz#c14bece03ee08be88467f22dc0ecf9cf875527cd"
+  integrity sha512-f4D5EXO7A7Xq35T0zRbWq5kJQyXzzscnHKmjnu2+37B3rwHU6mX9PYlbfXdnxcY6P/7zfmjhgan0Z+yuOfeBmA==
   dependencies:
     immer "^9.0.7"
     redux "^4.1.2"
@@ -2630,6 +2643,15 @@
   version "18.0.1"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.1.tgz#1b2e02fb7613212518733946e49fb963dfc66e19"
   integrity sha512-VnWlrVgG0dYt+NqlfMI0yUYb8Rdl4XUROyH+c6gq/iFCiZ805Vi//26UW38DHnxQkbDhnrIWTBiy6oKZqL11cw==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@^17.0.0 || ^18.0.0":
+  version "18.0.18"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.18.tgz#9f16f33d57bc5d9dca848d12c3572110ff9429ac"
+  integrity sha512-6hI08umYs6NaiHFEEGioXnxJ+oEhY3eRz8VCUaudZmGdtvPviCJB8mgaMxaDWAdPSYd4eFavrPk2QIolwbLYrg==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -8364,12 +8386,12 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
-redux-saga@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-1.1.3.tgz#9f3e6aebd3c994bbc0f6901a625f9a42b51d1112"
-  integrity sha512-RkSn/z0mwaSa5/xH/hQLo8gNf4tlvT18qXDNvedihLcfzh+jMchDgaariQoehCpgRltEm4zHKJyINEz6aqswTw==
+redux-saga@^1.1.3:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-1.2.1.tgz#3d730563c8d980525fa5e333ea1ee6e143452275"
+  integrity sha512-fVCicLlf4hLP+KB6H7RHfZlZ8LdYckhaemXBB3wh//a2ESyz/z/l8ygxlm0OqPjS/PARdsQ2hIdAltxEB+NgvA==
   dependencies:
-    "@redux-saga/core" "^1.1.3"
+    "@redux-saga/core" "^1.2.1"
 
 redux-thunk@^2.4.1:
   version "2.4.1"
@@ -9668,7 +9690,7 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@^8.3.0, uuid@^8.3.2:
+uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
### AdminPortal 6.2.0:
- [FR-8221](https://frontegg.atlassian.net/browse/FR-8221) - Add current version to wait for cdn - [9dd731dc](https://github.com/frontegg/admin-box/pulls?q=9dd731dc)

### AdminPortal 6.1.0:
- [FR-8221](https://frontegg.atlassian.net/browse/FR-8221) - fix versioning in lerna - [f93fef49](https://github.com/frontegg/admin-box/pulls?q=f93fef49)
- [FR-7960](https://frontegg.atlassian.net/browse/FR-7960) - fix current session - [0940a645](https://github.com/frontegg/admin-box/pulls?q=0940a645)
- [FR-8903](https://frontegg.atlassian.net/browse/FR-8903) - add infrastructure to customization testing - [30b691af](https://github.com/frontegg/admin-box/pulls?q=30b691af)