### PR TITLE
Update Frontegg AdminPortal to 6.9.0

### DIFF
--- a/libs/nextjs/package.json
+++ b/libs/nextjs/package.json
@@ -2,8 +2,8 @@
   "name": "@frontegg/nextjs",
   "version": "6.4.0",
   "dependencies": {
-    "@frontegg/js": "6.8.1",
-    "@frontegg/react-hooks": "6.8.1",
+    "@frontegg/js": "6.8.2",
+    "@frontegg/react-hooks": "6.8.2",
     "jose": "^4.8.0",
     "iron-session": "^6.2.1",
     "http-proxy": "^1.18.1",

--- a/libs/nextjs/package.json
+++ b/libs/nextjs/package.json
@@ -2,8 +2,8 @@
   "name": "@frontegg/nextjs",
   "version": "6.4.0",
   "dependencies": {
-    "@frontegg/js": "6.8.2",
-    "@frontegg/react-hooks": "6.8.2",
+    "@frontegg/js": "6.9.0",
+    "@frontegg/react-hooks": "6.9.0",
     "jose": "^4.8.0",
     "iron-session": "^6.2.1",
     "http-proxy": "^1.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1105,29 +1105,29 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@frontegg/js@6.8.1":
-  version "6.8.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.8.1.tgz#4998cb40ed84412cded17f364dffb15b834dca27"
-  integrity sha512-S9Pz4hYGXNUGsHboqnxK63US8yNXaYUO7P2lZISFzXD/0ifgwfBXafXXrZO3NWNGBhwr151rgFnxQBz1FRAk4A==
+"@frontegg/js@6.8.2":
+  version "6.8.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.8.2.tgz#5925e95d8d89b9392a86be3787db78410754f488"
+  integrity sha512-IEk6x2ZrRJGVqiwH1RJNpmuPa9hXZHvSOUWRPgCIyy8xtrH3XgUkEwNbEdv9QfG0RbhJcyGe5uD3Oh9XFHWOxg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.8.1"
+    "@frontegg/types" "6.8.2"
 
-"@frontegg/react-hooks@6.8.1":
-  version "6.8.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.8.1.tgz#0472bad69e4e74b2df47091b90877fa9f288143f"
-  integrity sha512-YE8xRRvF1Ux6WNWHXNH/0dmcLbdYBIBJoPN+vteCReBHAoIZk4c7h9ztowGeapDjjUqQkNgR8Krexo1wGtR8Rw==
+"@frontegg/react-hooks@6.8.2":
+  version "6.8.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.8.2.tgz#5e25ed5a702ec432ea41107671a19c3f9ba01f55"
+  integrity sha512-QtUdjOnyqk6QkYj7LXJOV/XIbj8nPYZARelYZN+Y1Xpp+UPnS85PU3f+yl6iCaoynNMAEet+qx++dkC/umqPHw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.8.1"
-    "@frontegg/types" "6.8.1"
+    "@frontegg/redux-store" "6.8.2"
+    "@frontegg/types" "6.8.2"
     "@types/react" "*"
     react-redux "^7.x"
 
-"@frontegg/redux-store@6.8.1":
-  version "6.8.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.8.1.tgz#e199e4b6a5091e42fbe97cfedea45736cddb981c"
-  integrity sha512-3ArBUnTqdnGtXwLC+c5q0KZfzNzBYCSxXokyHyEckBgmYMQL4+fuCkRr2LFJZ/9YLQIAthfElKb+3uevomLbfA==
+"@frontegg/redux-store@6.8.2":
+  version "6.8.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.8.2.tgz#4d4aa63ad7735a3940f2dbbb6d267b9ad271677c"
+  integrity sha512-50qMR2wxx0TBo+Ve74AxBx6eUiCyxJBYmZfLd8JQXGmZOYxNyeWtdOMrYRe6M/mJQi52TDKXZDS74gislfNTUQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "3.0.26"
@@ -1142,13 +1142,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.8.1":
-  version "6.8.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.8.1.tgz#4348e74250c687a2e2c4ecb0752e94229560c3f9"
-  integrity sha512-w5srGzLmoGoD8/KElY4GRIBub0LBYDeXiDJR5fDi3svTVyLFjtKaoRyR1A0WvlOCWtY4N9PIzR1xwvO2/dPOMg==
+"@frontegg/types@6.8.2":
+  version "6.8.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.8.2.tgz#5271752c908dc665aa06cca4db09de18c6dec825"
+  integrity sha512-+GkRM+5NZNgXvdePIC/7DL4yOR3fxa84OFFFQZe3JFN45jgoHzwSpiK/IK3UW6u1bfNkHb1N4wq7VureGsYRDQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.8.1"
+    "@frontegg/redux-store" "6.8.2"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1105,29 +1105,29 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@frontegg/js@6.8.2":
-  version "6.8.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.8.2.tgz#5925e95d8d89b9392a86be3787db78410754f488"
-  integrity sha512-IEk6x2ZrRJGVqiwH1RJNpmuPa9hXZHvSOUWRPgCIyy8xtrH3XgUkEwNbEdv9QfG0RbhJcyGe5uD3Oh9XFHWOxg==
+"@frontegg/js@6.9.0":
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.9.0.tgz#05e0c9fd3decc4271af568cec6ca9a659271109f"
+  integrity sha512-pE5GhgMtbwKyJaA/gHSFsKl6fa6ClL2EBKTuRJvAqN5hTnjxUiMc13NdL2KcPqG+jnvK+qz2om6Z4/t4bK3cgQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.8.2"
+    "@frontegg/types" "6.9.0"
 
-"@frontegg/react-hooks@6.8.2":
-  version "6.8.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.8.2.tgz#5e25ed5a702ec432ea41107671a19c3f9ba01f55"
-  integrity sha512-QtUdjOnyqk6QkYj7LXJOV/XIbj8nPYZARelYZN+Y1Xpp+UPnS85PU3f+yl6iCaoynNMAEet+qx++dkC/umqPHw==
+"@frontegg/react-hooks@6.9.0":
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.9.0.tgz#b16a88736e75ebd43bb26b9846e40487bf30b2a8"
+  integrity sha512-Cc6bw3Y0FulcCgwireOehJcXSmezU7FVkA+VGGOtqGl2U4OxspR19N8Lz+Y+uNTBVFqH1OaYF4bF5VzlHFWwUg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.8.2"
-    "@frontegg/types" "6.8.2"
+    "@frontegg/redux-store" "6.9.0"
+    "@frontegg/types" "6.9.0"
     "@types/react" "*"
     react-redux "^7.x"
 
-"@frontegg/redux-store@6.8.2":
-  version "6.8.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.8.2.tgz#4d4aa63ad7735a3940f2dbbb6d267b9ad271677c"
-  integrity sha512-50qMR2wxx0TBo+Ve74AxBx6eUiCyxJBYmZfLd8JQXGmZOYxNyeWtdOMrYRe6M/mJQi52TDKXZDS74gislfNTUQ==
+"@frontegg/redux-store@6.9.0":
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.9.0.tgz#67e042c978e69fd5e9f09c275e5fb2be30af3c68"
+  integrity sha512-qbfgrj2IKPsa/LnPFjSpsKy5yC0I9aGWWlhmKkmsP5ZezdskhVDKFlTQEXpDwHHQc/KUrw/0LBjziI3QEp6Q6w==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "3.0.26"
@@ -1142,13 +1142,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.8.2":
-  version "6.8.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.8.2.tgz#5271752c908dc665aa06cca4db09de18c6dec825"
-  integrity sha512-+GkRM+5NZNgXvdePIC/7DL4yOR3fxa84OFFFQZe3JFN45jgoHzwSpiK/IK3UW6u1bfNkHb1N4wq7VureGsYRDQ==
+"@frontegg/types@6.9.0":
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.9.0.tgz#0dd5a8d92848c97393d0f8ea69ad2d335d8c325c"
+  integrity sha512-Twx2H1oyS15V98Dl6kP1u8x/4D4+qls17j+UwaZFBKsBfkD3J1Wd4I1segRuOGWzzoRqFsEClLkfBzqgVnsBrw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.8.2"
+    "@frontegg/redux-store" "6.9.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
### AdminPortal 6.9.0:
- [FR-9157](https://frontegg.atlassian.net/browse/FR-9157) - Display an alert when the user has not provided base url option - [5686fa47](https://github.com/frontegg/admin-box/pulls?q=5686fa47)
- [FR-9153](https://frontegg.atlassian.net/browse/FR-9153) - make sure to clear interval and event listener router - [f278bc9b](https://github.com/frontegg/admin-box/pulls?q=f278bc9b)
- [FR-9151](https://frontegg.atlassian.net/browse/FR-9151) - Render github button label as GitHub instead of Github - [9bfb4f15](https://github.com/frontegg/admin-box/pulls?q=9bfb4f15)

### AdminPortal 6.8.2:
- [FR-9147](https://frontegg.atlassian.net/browse/FR-9147) - Make sure to not set doc title if login box rendered in builder mode - [6734f56c](https://github.com/frontegg/admin-box/pulls?q=6734f56c)