### PR TITLE
FR-9187 - split cookie if exceeds length of 4096

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ cypress/videos
 cypress/screenshots
 .idea
 .env
+.env.local

--- a/libs/nextjs/src/FronteggMiddleware.ts
+++ b/libs/nextjs/src/FronteggMiddleware.ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import httpProxy from 'http-proxy';
-import cookie from 'cookie';
 import fronteggConfig from './FronteggConfig';
 import {
   addToCookies,
+  createCookie,
   createSessionFromAccessToken,
   modifySetCookieIfUnsecure,
   removeCookies,
@@ -133,23 +133,11 @@ export function fronteggMiddleware(
                 output
               );
               if (session) {
-                const cookieValue = cookie.serialize(
-                  fronteggConfig.cookieName,
+                const cookieValue = createCookie({
                   session,
-                  {
-                    expires: new Date(decodedJwt.exp * 1000),
-                    httpOnly: true,
-                    domain: fronteggConfig.cookieDomain,
-                    path: '/',
-                    sameSite: isSecured ? 'none' : undefined,
-                    secure: isSecured,
-                  }
-                );
-                if (cookieValue.length > 4096) {
-                  console.error(
-                    `@frontegg/nextjs: Cookie length is too big ${cookieValue.length}, browsers will refuse it. Try to remove some data.`
-                  );
-                }
+                  expires: new Date(decodedJwt.exp * 1000),
+                  isSecured
+                })
                 addToCookies(cookieValue, serverResponse);
               }
             }

--- a/libs/nextjs/src/session.ts
+++ b/libs/nextjs/src/session.ts
@@ -1,6 +1,5 @@
 import { IncomingMessage } from 'http';
 import { FronteggNextJSSession } from './types';
-import cookie from 'cookie';
 import fronteggConfig from './FronteggConfig';
 import { unsealData } from 'iron-session';
 import { jwtVerify } from 'jose';
@@ -12,7 +11,7 @@ import {
 } from 'next';
 import FronteggConfig from './FronteggConfig';
 import { authInitialState } from '@frontegg/redux-store';
-import { uncompress } from './helpers';
+import { parseCookie, uncompress } from './helpers';
 
 type RequestType = IncomingMessage | Request;
 
@@ -22,7 +21,7 @@ export async function getSession(
   try {
     const cookieStr = "credentials" in req ? req.headers.get("cookie") || "" : req.headers.cookie || "";
 
-    const sealFromCookies = cookie.parse(cookieStr)[fronteggConfig.cookieName];
+    const sealFromCookies = parseCookie(cookieStr)
     if (!sealFromCookies) {
       return undefined;
     }


### PR DESCRIPTION
In this pr we change the way we treat session cookie.

there is a new check if the encrypted cookies size is bigger than 4096 we split it into the amount of cookies required for it to be less then 4096 and suffix their names with number (1,2,3...). 

Then to read it, we check whether one cookie is exist with the client conifg cookie name, if not we check if multiple cookies and if yes we iterate them with the new suffix (1,2,3...) and concating them all together to the one big encrypted cookies