### PR TITLE
Update Frontegg AdminPortal to 6.43.0

### DIFF
--- a/libs/nextjs/package.json
+++ b/libs/nextjs/package.json
@@ -2,8 +2,8 @@
   "name": "@frontegg/nextjs",
   "version": "6.7.3",
   "dependencies": {
-    "@frontegg/js": "6.42.0",
-    "@frontegg/react-hooks": "6.42.0",
+    "@frontegg/js": "6.43.0",
+    "@frontegg/react-hooks": "6.43.0",
     "jose": "^4.9.2",
     "iron-session": "^6.2.1",
     "http-proxy": "^1.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1105,50 +1105,50 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@frontegg/js@6.42.0":
-  version "6.42.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.42.0.tgz#1cd6fdb1085a160a0802480423a17bf1cd48d6b8"
-  integrity sha512-QtxSX0qe16b+vdwI3ZeaIcC1vMGhf9VAAPdx7tLpWF1xxcUfAHYlXQtKYZFqQ+ydGC6Dpsy2IRSohd8Ag6CsPQ==
+"@frontegg/js@6.43.0":
+  version "6.43.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.43.0.tgz#6ca7194ed87527a3f22ad335a7b4619832af4dc0"
+  integrity sha512-0HhBhXkM6EZCfUVJE2YIaK3ZsO7TQ1ALIJY1yofZJ9tkQR/j/MeBu7sVP5TDBeWzI7EuxYdjRYPEJI33VCQ3wQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.42.0"
+    "@frontegg/types" "6.43.0"
 
-"@frontegg/react-hooks@6.42.0":
-  version "6.42.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.42.0.tgz#828cdb79d797b3afffadf458ef0fa9793217b15c"
-  integrity sha512-Afyu+8dOihiBLCGAR/1eK82szknQhyBoC5Z2jC6FPrNTAWAwnEqktg6pMhxfyyPx9MfJvOnTHOpINDOK5WvK3Q==
+"@frontegg/react-hooks@6.43.0":
+  version "6.43.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.43.0.tgz#909c95760d15dc097f65a5870f6f5afbde3ac8fd"
+  integrity sha512-omtSuNVJADTRdb2F3wSKYol8U3GhOdc+MEC0FQ8jH1UrOMw8hCVeGBdUOokjMjpbrzTRIgoG4HumMgDf0EM63Q==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.42.0"
-    "@frontegg/types" "6.42.0"
+    "@frontegg/redux-store" "6.43.0"
+    "@frontegg/types" "6.43.0"
     "@types/react" "*"
     react-redux "^7.x"
 
-"@frontegg/redux-store@6.42.0":
-  version "6.42.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.42.0.tgz#f492dfb733669e6e88409197f831b9016d58bebb"
-  integrity sha512-tWKs8t/i6IypDgOJix0udE6Y1YKLypWInXTL8Bby1hlOpUN668YVznpvv5b5EE7iQ/KFCpqJglwpqLslKdDZAA==
+"@frontegg/redux-store@6.43.0":
+  version "6.43.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.43.0.tgz#364977e4a33c50ddbde406d90ecc903b109d2fc4"
+  integrity sha512-fI4mweHERaXiDtr3yISkDk7z1EofAbu9VqhirOC5p4GGscF6escJR8iBgx31cG91r2tsMkfisSk3MB9wGpTtPA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/rest-api" "3.0.32"
+    "@frontegg/rest-api" "3.0.34"
     "@reduxjs/toolkit" "^1.8.5"
     redux-saga "^1.2.1"
     uuid "^8.3.2"
 
-"@frontegg/rest-api@3.0.32":
-  version "3.0.32"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.32.tgz#fac182f8cb254245d13b5c4634034a978db798c2"
-  integrity sha512-H0l5+gTPGoALGM+K80ODkQJiv4aJS1aRYcZNdU0qWdnFU/1SWOyu7syNsBSmteha5/IytI/GiWhKtIg5Lt1Gdw==
+"@frontegg/rest-api@3.0.34":
+  version "3.0.34"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.34.tgz#f023221ceced8ad34ab7c62dc8a30288946f6b0d"
+  integrity sha512-hJWVB0ebEAFjQ4kbxngvkfq5QokPTPMSl3OP/Kv+VXbV6A76B9aa82uE7xgC5y/lEr2kldQ6UoGRdtIxZtLBsA==
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.42.0":
-  version "6.42.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.42.0.tgz#d52bda51b0b9219cfad7b51185cf23cd4c6e1752"
-  integrity sha512-fEukLyK9ZO3kDlYNKxZ0/6Du88m3fJi2IkS9ecmy39thR9P2wxzUqKqBR4/eMw5pafyy5tHpzZfMwjmWKx/acA==
+"@frontegg/types@6.43.0":
+  version "6.43.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.43.0.tgz#64ca440c705ffb270054ed556d2ad4f6e887fc3c"
+  integrity sha512-EaDHni0EkWacQjgmJtk8Wb+jLTX0H/EbDAvdJfA5R0OnP9+OcUOuIaxXUp/b+G+almBagwXBQFa87cKCjsmxbA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.42.0"
+    "@frontegg/redux-store" "6.43.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-9664 - update @frontegg/rest-api
- FR-9661 - fix chips in dark them
- FR-9653 - fix hide fields session management
- FR-9659 - inherit button dark them
- FR-9655 - fix dialog and select dark them
- FR-8948 - Fix - clean error message from sign up page when visiting it again
- FR-9624 - typo + snyk git ignore
- FR-9629 - typography should be white in dark theme
- FR-9625 - empty table in dark theme
- FR-9631 - resize the login box when logo is null
- FR-9176 - hide fields security and account details pages
- FR-8714 - Fix ReCaptcha timeout