### PR TITLE
Update Frontegg AdminPortal to 6.47.0

### DIFF
--- a/libs/nextjs/package.json
+++ b/libs/nextjs/package.json
@@ -2,8 +2,8 @@
   "name": "@frontegg/nextjs",
   "version": "6.7.3",
   "dependencies": {
-    "@frontegg/js": "6.46.0",
-    "@frontegg/react-hooks": "6.46.0",
+    "@frontegg/js": "6.47.0",
+    "@frontegg/react-hooks": "6.47.0",
     "jose": "^4.9.2",
     "iron-session": "^6.2.1",
     "http-proxy": "^1.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1105,29 +1105,29 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@frontegg/js@6.46.0":
-  version "6.46.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.46.0.tgz#bccede6f0625f056e3b483ebfb72a67ddab38b7f"
-  integrity sha512-4XzIlvdg0REPYse9ZbjiEzf8lLpTY/fo+kgEGzI3Ftg55+9joQv4niE1ZFt69/ft0ExYhchuiOKSCBGTxZ+7KA==
+"@frontegg/js@6.47.0":
+  version "6.47.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.47.0.tgz#27cfbfe556101187267bfb58c2096472d12cbc93"
+  integrity sha512-XiEqzZcIwGdo9h6B5UxVrSdW/89i7Z6vKViewrS6MYSf/MEFzuAqSMHLr4cMgwSa23FemIsDh3ZlpwZEUy7K4A==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.46.0"
+    "@frontegg/types" "6.47.0"
 
-"@frontegg/react-hooks@6.46.0":
-  version "6.46.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.46.0.tgz#81ad3555d78e3b17c1109cdf239934d495fe9008"
-  integrity sha512-8IIx3HE/UQLJcCxYrqIeEXk66Gq8OJ+Xe+iyhD5iKB/e8nf9rQiRi0YwXYUpKCNwHW4KvzKRzm8U2hgPx1eMIA==
+"@frontegg/react-hooks@6.47.0":
+  version "6.47.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.47.0.tgz#4c21a93df3390641e4e78037fb6b6f3bb85e4607"
+  integrity sha512-vxyIvZMQBDnKyFoXufhWmMvVI6t9OBzZd++qTTaO+rfyghFr4ddGla0oHpWgznBw2nsuqIGSXc//+Zt9AlAsJg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.46.0"
-    "@frontegg/types" "6.46.0"
+    "@frontegg/redux-store" "6.47.0"
+    "@frontegg/types" "6.47.0"
     "@types/react" "*"
     react-redux "^7.x"
 
-"@frontegg/redux-store@6.46.0":
-  version "6.46.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.46.0.tgz#1135c5ffbf2ff155911f051a9cad176e7daecb15"
-  integrity sha512-Yl78DXcu0OBUgeSM3mXmjJdnv9aqfBlOClaGlg1+aaj7xjJ19s8QnKlDjynY05TYmmlpdkV+ogIVzKKUCDQwow==
+"@frontegg/redux-store@6.47.0":
+  version "6.47.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.47.0.tgz#998a47df69e5ae65445bedc52fc2421846fe6365"
+  integrity sha512-FJe5VmcRrf2G8h/D9D3dS1rdyT+2C64tuwJHRObDbhiAP4+MGT09cIKvY2Zl4bGGjrB8982XRbnUzKHUMaAsww==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "^3.0.39"
@@ -1142,13 +1142,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.46.0":
-  version "6.46.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.46.0.tgz#d9b4ba2fe1643df7fa33fa05d1fcb80b90e0b87a"
-  integrity sha512-zvRo6pLqmUQ22U6qrBRuI3COc8+3mEBwb5qlu0Be3759Zh4hc2p0/7pTnLSsXpnvQwmBAeH4MlmOTDO9jPbTyw==
+"@frontegg/types@6.47.0":
+  version "6.47.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.47.0.tgz#6ec4745a1c14c0df40ec34b4735e181e7b58aedc"
+  integrity sha512-+qo8dQMj/aqZ9cbeQiR6989E/5CJvex0REyeAV9MrA4SgLFK83fvEK7jVWnYrFYwyY5SwsFzgTdBfF3cr6nH0w==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.46.0"
+    "@frontegg/redux-store" "6.47.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-9852 - Support copy invite link for dynamic base URL as well (mainly for Next.js)
- FR-9742 - login with mfa
- FR-9520 - FR-9504 - fonts improvements