### PR TITLE
Update Frontegg AdminPortal to 6.58.0

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -13,8 +13,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/js": "6.53.0",
-    "@frontegg/react-hooks": "6.53.0",
+    "@frontegg/js": "6.58.0",
+    "@frontegg/react-hooks": "6.58.0",
     "@types/http-proxy": "^1.17.9",
     "cookie": "^0.5.0",
     "http-proxy": "^1.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -370,50 +370,50 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@frontegg/js@6.53.0":
-  version "6.53.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.53.0.tgz#0a1e275fc10d86fec337e710d9a4dd15be41624d"
-  integrity sha512-DFJxE3HQlpWh1WCjxKbK71WEdDAVNhKQKR8uXNgsiKk8dtof21yZiaVG2pN8Tn2iDe34vv5BoK5e2UzNXBxOsw==
+"@frontegg/js@6.58.0":
+  version "6.58.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.58.0.tgz#af56e76b572b2e6b97519d026a4e722df6539d97"
+  integrity sha512-x9pH+SzcBvfpvECyiqH4y9tISwN3Vufy+8PxK1FwWzSF/sKDRYD2J7uoUmayIJL2Vd/COBpKeMuKm3vxMK4dDQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.53.0"
+    "@frontegg/types" "6.58.0"
 
-"@frontegg/react-hooks@6.53.0":
-  version "6.53.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.53.0.tgz#054bca93172df53ef1175f89b602e5f5befbce84"
-  integrity sha512-Cukle37RUR5hL3cr+s6EA6Lc80gGb4b1bsT9CtMMLfQho4Uu8TGnbYg5uCyS+LHUyxFuQVxjRqEJleEeYrNxFg==
+"@frontegg/react-hooks@6.58.0":
+  version "6.58.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.58.0.tgz#3a427ed8c733ff7a39ebd3c868f8c9d0c4f262a9"
+  integrity sha512-h0h73g8IraiyeYSRi3rwnIHi5CclcA8K9xuEgLIVgyzKScIh5jYGnT5lxOanpQIuxY63ZzXqRuQIGp2LM5ylew==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.53.0"
-    "@frontegg/types" "6.53.0"
+    "@frontegg/redux-store" "6.58.0"
+    "@frontegg/types" "6.58.0"
     "@types/react" "*"
     react-redux "^7.x"
 
-"@frontegg/redux-store@6.53.0":
-  version "6.53.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.53.0.tgz#ddcbd68a6cdd64ee6e8987e5bb83ebf8fd8e78d4"
-  integrity sha512-RAyowKn1r65kZ8wS+KBW/SdDkWQZoZnTghgxfQrzIl/sVQ5Irgj+OUO7o/B558DBXQwaCjXmACejXm56unTApQ==
+"@frontegg/redux-store@6.58.0":
+  version "6.58.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.58.0.tgz#4bdbf2b5706476a4d366b5a1fe672c86176eadd4"
+  integrity sha512-l7w2ZVKa8WjlclVydLVx3WwH+7o9dbV3JmDVigp9G1gzTuI604tbrSeXUVWmTwNmopPlZ8maTKGWMXXeizauLw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/rest-api" "^3.0.52"
+    "@frontegg/rest-api" "^3.0.54"
     "@reduxjs/toolkit" "^1.8.5"
     redux-saga "^1.2.1"
     uuid "^8.3.2"
 
-"@frontegg/rest-api@^3.0.52":
-  version "3.0.52"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.52.tgz#c29baed132eeab9110c8b28a6cebf8dd425b2737"
-  integrity sha512-Ne3gnDEhN3EkYPrNqHBaIc/ETrd2N/AeP/xYq5+usLlAbCCjMgjTBHZGYCh9HChhKb0P6xhzfFf19Q1LwL2mDg==
+"@frontegg/rest-api@^3.0.54":
+  version "3.0.58"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.58.tgz#cf1c75efc99522d4c1a65630cdf9721374ed29bf"
+  integrity sha512-tLILYmPA5Qt8tI5ifg9X3/qwuNBAW3igpJB2+PYk2maCPfi9rXtrBtyh6TuLFtzgEq7W4ZdiPSdcrL879mKDaw==
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.53.0":
-  version "6.53.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.53.0.tgz#f7f02e3bf0a3f262534c037314227a519da11dd0"
-  integrity sha512-G9ZuM9UrOaBfv3lbXTmhTC/RMxBEKWf/ZSPDfH8LJEN8C/xeuM4Jo3inGuzjlSZ0ocaUqFp3DOOI+PuLuP6mOw==
+"@frontegg/types@6.58.0":
+  version "6.58.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.58.0.tgz#7d2607a364f746e2a2437daa71f4e1cd16c4ddcf"
+  integrity sha512-QprNIzjCE8fCK0lGNYqPIW+cA8N9A5UJsAWRzRMwc1xFCwdhWtzTXGt2XBhjkrtzrP/O9oxuZEErSw/F7U09fw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.53.0"
+    "@frontegg/redux-store" "6.58.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
FR-10275 - Avoid calling conditioned hook in Google onetap code

FR-9413 - fix main login validation for on boarding

FR-10241 - added support for redirectUrl on prelogin

FR-10240 - remove linkedin from inactive providers

FR-9983 - make sure that OTC fields are in one column with submit button

FR-9642 - Logout on OAuth service on Hosted Login

FR-8022 - support linkedin

FR-10212 - hide disabled cards from mfa list

FR-10162 - added support for google one tap

FR-9983 - Improve digits component

FR-9987 - fix social btns UI

FR-9413 - Login, unified behaviour

FR-10047 - fix bad UI webhook

FR-9993 - Add custom event to add user by bulk

FR-10118 - fix apple logo color change when font color changes

FR-9976 - refactor otc