### PR TITLE
Update Frontegg AdminPortal to 6.68.0

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -13,8 +13,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/js": "6.65.0",
-    "@frontegg/react-hooks": "6.65.0",
+    "@frontegg/js": "6.67.0",
+    "@frontegg/react-hooks": "6.67.0",
     "@types/http-proxy": "^1.17.9",
     "cookie": "^0.5.0",
     "http-proxy": "^1.18.1",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -13,8 +13,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/js": "6.67.0",
-    "@frontegg/react-hooks": "6.67.0",
+    "@frontegg/js": "6.68.0",
+    "@frontegg/react-hooks": "6.68.0",
     "@types/http-proxy": "^1.17.9",
     "cookie": "^0.5.0",
     "http-proxy": "^1.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -370,50 +370,50 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@frontegg/js@6.65.0":
-  version "6.65.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.65.0.tgz#2acad4e548e50201d2a226ea9469afee8807135b"
-  integrity sha512-rBZ9Gz2dh11kOBdrh4aRGL+S5PjhaLZ1o27GkiZJrlqU4V/18ViHpQZSfNqj3OODGDfjB4OChShou2vYHXUd9w==
+"@frontegg/js@6.67.0":
+  version "6.67.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.67.0.tgz#ddd8d242842160a35c55ca5071befae607883f1e"
+  integrity sha512-gQCk0LR6MlbfIOgvYLJ/Oh2vl04zo3F/OJ6NBupDwko1KEqHOS+h+nrIw22KD6AW1j3A3mzehd7n44ivKizoEw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.65.0"
+    "@frontegg/types" "6.67.0"
 
-"@frontegg/react-hooks@6.65.0":
-  version "6.65.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.65.0.tgz#eff631c093b2884dbe407a03e0ef79b795a6deb2"
-  integrity sha512-ffRARj4Nmq01UfeAsZOzB9Y1C3XTnh5pxS/K2XD5dl03nGgCvWGLWGjgN3nCLXHWL/f3OXlu+zMy0X3NU1yXAg==
+"@frontegg/react-hooks@6.67.0":
+  version "6.67.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.67.0.tgz#7f06e52c2c982d85eb9f6354edfb9b2277677c23"
+  integrity sha512-CnhA56fFsSPmRne+Vg9FZC6YC3eiVPUczuuegBTSmvrxWGU4yP7aPbOvCHwM4hwPDbyITOZZgvkU+CrgCTPgiQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.65.0"
-    "@frontegg/types" "6.65.0"
+    "@frontegg/redux-store" "6.67.0"
+    "@frontegg/types" "6.67.0"
     "@types/react" "*"
     react-redux "^7.x"
 
-"@frontegg/redux-store@6.65.0":
-  version "6.65.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.65.0.tgz#46e406cca1016d80dcad3acde7da13ce5844ea67"
-  integrity sha512-AkaHGogs5ngIssNQ5dbM1XjecRdLYFoJZ1+aiBu5vxtQ2/6m6zkEFjScSlL4B7cHTESDXlmXMVIrlakLc79FoQ==
+"@frontegg/redux-store@6.67.0":
+  version "6.67.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.67.0.tgz#3ece62bce3cc6570d8ae94d3c9c772168320dab4"
+  integrity sha512-b+RRE1MuCJLL1yIEoagEoC0ZcCHAedW4xBPjGbarYA9fV3GaC7NqXJ3WQA73pzkYKyBM8dqnJ83rnZ5rcBGUdA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/rest-api" "^3.0.63"
+    "@frontegg/rest-api" "3.0.71"
     "@reduxjs/toolkit" "^1.8.5"
     redux-saga "^1.2.1"
     uuid "^8.3.2"
 
-"@frontegg/rest-api@^3.0.63":
-  version "3.0.63"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.63.tgz#e64781f68d1d09aa6be84912a43808ac505aa06a"
-  integrity sha512-Cv2Pak3/IGPDPVrvnWLXE7nh/iOPcdAQJtqgW6nYC27jDlTBpKu3cx+RP7pUDi+Ezltes/bYMXdK/e3qgzPTvQ==
+"@frontegg/rest-api@3.0.71":
+  version "3.0.71"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.71.tgz#87c3379563143786a67127cbb4965f6147b203ea"
+  integrity sha512-cMWi2jc/YM5v9osF5ofkXgIygZjgs4OiS+eOQUTwDvpOqkwJSpZ9T0r1r6E1YgOA3yFMPONBA8hrC4HUXeKHIg==
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.65.0":
-  version "6.65.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.65.0.tgz#aaa98a783af209c9195430abfed9ccd0030574fc"
-  integrity sha512-GPJG3SB8Vy+me2n/MgwXkFGQzIEz6A5XpsqRbgXuWzD+vKmmlgwLYiwUhnmzl5BowRjTJQ+ABqNisXdzGswfkg==
+"@frontegg/types@6.67.0":
+  version "6.67.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.67.0.tgz#3fa0980bbd12297128de88018bcdc16f546df521"
+  integrity sha512-Mus6W5c6KfhUnsk4FSa0n4WPDJSFJq67WpC8jpvo2jYDh2u7MQm67zouGrkprdkSjhMWIeNdkQHQY1rpoNdAug==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.65.0"
+    "@frontegg/redux-store" "6.67.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -370,29 +370,29 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@frontegg/js@6.67.0":
-  version "6.67.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.67.0.tgz#ddd8d242842160a35c55ca5071befae607883f1e"
-  integrity sha512-gQCk0LR6MlbfIOgvYLJ/Oh2vl04zo3F/OJ6NBupDwko1KEqHOS+h+nrIw22KD6AW1j3A3mzehd7n44ivKizoEw==
+"@frontegg/js@6.68.0":
+  version "6.68.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.68.0.tgz#b5535a4775b12f71e02ca8587dcf15254f51d272"
+  integrity sha512-xw4CcF1qRNFZPwxECr3KXjUKQaGUDhkots6iRzlA2jHaN+BGUv5zenbKKsFQic3R9DWbIDj180DcZbag2qPWzA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.67.0"
+    "@frontegg/types" "6.68.0"
 
-"@frontegg/react-hooks@6.67.0":
-  version "6.67.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.67.0.tgz#7f06e52c2c982d85eb9f6354edfb9b2277677c23"
-  integrity sha512-CnhA56fFsSPmRne+Vg9FZC6YC3eiVPUczuuegBTSmvrxWGU4yP7aPbOvCHwM4hwPDbyITOZZgvkU+CrgCTPgiQ==
+"@frontegg/react-hooks@6.68.0":
+  version "6.68.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.68.0.tgz#564e2479f7d303e88fa9b2c5d1d502a0b97b3e2b"
+  integrity sha512-lznEefgnvSWV5sIruJ4o0gnJHDACKPhCfbveVOK2qsSg+/M+oVZOG+YJP0UOhddCuNsFzHR1ctbWkhi1tcU7mQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.67.0"
-    "@frontegg/types" "6.67.0"
+    "@frontegg/redux-store" "6.68.0"
+    "@frontegg/types" "6.68.0"
     "@types/react" "*"
     react-redux "^7.x"
 
-"@frontegg/redux-store@6.67.0":
-  version "6.67.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.67.0.tgz#3ece62bce3cc6570d8ae94d3c9c772168320dab4"
-  integrity sha512-b+RRE1MuCJLL1yIEoagEoC0ZcCHAedW4xBPjGbarYA9fV3GaC7NqXJ3WQA73pzkYKyBM8dqnJ83rnZ5rcBGUdA==
+"@frontegg/redux-store@6.68.0":
+  version "6.68.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.68.0.tgz#fb05719cfa0de77574b1131ba9bcbbb312ebb627"
+  integrity sha512-azUiakpesbC9fcmTOQl57pojin1sVefh9j5ZXiscwxrobi8WtyLCm3ciZo/xD4zITOg+3uYDPx5vAiKFp9pgbQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "3.0.71"
@@ -407,13 +407,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.67.0":
-  version "6.67.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.67.0.tgz#3fa0980bbd12297128de88018bcdc16f546df521"
-  integrity sha512-Mus6W5c6KfhUnsk4FSa0n4WPDJSFJq67WpC8jpvo2jYDh2u7MQm67zouGrkprdkSjhMWIeNdkQHQY1rpoNdAug==
+"@frontegg/types@6.68.0":
+  version "6.68.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.68.0.tgz#85723a5a94c6d7b829937c9f1d17166f2313ce51"
+  integrity sha512-I6ycunr1a3R1XjfDO5BvYPBrt6cegKfBBZKwjOulOeOAqrnf1Xo9LrT+yxExn1GqPZy4HtmcOlgOvCGE6IpmIA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.67.0"
+    "@frontegg/redux-store" "6.68.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- 

- FR-10485 - Update restapi version
- FR-10017 - add email type to all email inputs
- FR-10501 - Fix mobile width of login box
- FR-10196 - Fix scroll in privacy page
- FR-10489 - update scim ui
- FR-10483 - Added the option to customize forget password button
- FR-10374 - improve values ui in split mode
- FR-10184 - add access tokens
- FR-9995 - Accept Invitation text and icon change