### PR TITLE
FR-10721 - refactors and improvements for nextjs middleware redirect 

### DIFF
--- a/packages/demo-saas-next12/middleware.ts
+++ b/packages/demo-saas-next12/middleware.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
-import { getSession, shouldByPassMiddleware } from '@frontegg/nextjs/edge';
+import { getSession, shouldByPassMiddleware, redirectToLogin } from '@frontegg/nextjs/edge';
 
 export const middleware = async (request: NextRequest) => {
   // this if for frontegg middleware tests
@@ -10,19 +10,13 @@ export const middleware = async (request: NextRequest) => {
 
   const pathname = request.nextUrl.pathname;
 
-  if (
-    shouldByPassMiddleware(pathname, {
-      bypassImageOptimization: false,
-    })
-  ) {
+  if (shouldByPassMiddleware(pathname)) {
     return NextResponse.next();
   }
 
   const session = await getSession(request);
   if (!session) {
-    //  redirect unauthenticated user to /account/login page
-    const loginUrl = `/account/login?redirectUrl=${encodeURIComponent(pathname)}`;
-    return NextResponse.redirect(new URL(loginUrl, process.env['FRONTEGG_APP_URL']));
+    return redirectToLogin(pathname);
   }
   return NextResponse.next();
 };

--- a/packages/nextjs/src/common/client/createOrGetFronteggApp.ts
+++ b/packages/nextjs/src/common/client/createOrGetFronteggApp.ts
@@ -1,10 +1,11 @@
 import { AppHolder, FronteggApp, initialize } from '@frontegg/js';
 import { createFronteggStore, AuthState, tenantsState as defaultTenantsState } from '@frontegg/redux-store';
-import { fronteggAuthApiRoutes, KeyValuePair } from '@frontegg/rest-api';
+import { KeyValuePair } from '@frontegg/rest-api';
 import { FronteggAppOptions } from '@frontegg/types';
 import sdkVersion from '../../sdkVersion';
 import { FronteggProviderOptions } from '../types';
 import nextjsPkg from 'next/package.json';
+import { isAuthPath, isSocialLoginPath } from '../helpers';
 
 type CreateOrGetFronteggAppParams = {
   options: FronteggProviderOptions;
@@ -12,11 +13,6 @@ type CreateOrGetFronteggAppParams = {
   appName?: string;
   storeHolder: any;
 };
-
-const isAuthPath = (path: string) =>
-  fronteggAuthApiRoutes.indexOf(path) !== -1 || path.endsWith('/postlogin') || path.endsWith('/prelogin');
-const isSocialLoginPath = (path: string) =>
-  RegExp('^/identity/resources/auth/v[0-9]*/user/sso/default/.*/prelogin$').test(path);
 
 export const createOrGetFronteggApp = ({
   options,

--- a/packages/nextjs/src/common/helpers.ts
+++ b/packages/nextjs/src/common/helpers.ts
@@ -3,6 +3,8 @@ import { jwtVerify } from 'jose';
 import { getTenants, getUsers } from './api';
 import FronteggConfig from './FronteggConfig';
 import { FronteggNextJSSession, FronteggUserTokens, AllUserData } from './types';
+import { fronteggAuthApiRoutes } from '@frontegg/rest-api';
+
 const calculateExpiresInFromExp = (exp: number) => Math.floor((exp * 1000 - Date.now()) / 1000);
 
 export async function createSessionFromAccessToken(data: any): Promise<[string, any, string] | []> {
@@ -56,3 +58,9 @@ export const getAllUserData = async ({ getSession, reqHeaders }: UserDataArgumen
     return {};
   }
 };
+
+export const isAuthPath = (path: string) =>
+  fronteggAuthApiRoutes.indexOf(path) !== -1 || path.endsWith('/postlogin') || path.endsWith('/prelogin');
+
+export const isSocialLoginPath = (path: string) =>
+  RegExp('^/identity/resources/auth/v[0-9]*/user/sso/default/.*/prelogin$').test(path);

--- a/packages/nextjs/src/edge/index.ts
+++ b/packages/nextjs/src/edge/index.ts
@@ -1,2 +1,3 @@
 export * from './getSessionOnEdge';
 export * from './shouldBypassMiddleware';
+export * from './redirectToLogin';

--- a/packages/nextjs/src/edge/redirectToLogin.ts
+++ b/packages/nextjs/src/edge/redirectToLogin.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server';
+
+export const redirectToLogin = (pathname: string) => {
+  const loginUrl = `/account/login?redirectUrl=${encodeURIComponent(pathname)}`;
+  return NextResponse.redirect(new URL(loginUrl, process.env['FRONTEGG_APP_URL']));
+};

--- a/packages/nextjs/src/edge/shouldBypassMiddleware.ts
+++ b/packages/nextjs/src/edge/shouldBypassMiddleware.ts
@@ -1,6 +1,6 @@
 interface ByPassOptions {
   bypassStaticFiles?: boolean; // default: true
-  bypassImageOptimization?: boolean; // default: false
+  bypassImageOptimization?: boolean; // default: true
   bypassHeaderRequests?: boolean; // default: true
 }
 

--- a/packages/nextjs/src/refreshToken.ts
+++ b/packages/nextjs/src/refreshToken.ts
@@ -1,24 +1,10 @@
 import { fronteggRefreshTokenUrl } from '@frontegg/rest-api';
 import { NextApiRequest, NextPageContext } from 'next/dist/shared/lib/utils';
-import {
-  FronteggNextJSSession,
-  createSessionFromAccessToken,
-  getTokensFromCookie,
-  CookieManager,
-  FronteggUserTokens,
-  createGetSession,
-} from './common';
+import { FronteggNextJSSession, createSessionFromAccessToken, getTokensFromCookie, CookieManager } from './common';
 import nextjsPkg from 'next/package.json';
 import sdkVersion from './sdkVersion';
-import { unsealData } from 'iron-session';
 import FronteggConfig from './common/FronteggConfig';
-
-async function getTokensFromCookieOnEdge(cookie: string): Promise<FronteggUserTokens | undefined> {
-  const jwt: string = await unsealData(cookie, {
-    password: FronteggConfig.passwordsAsMap,
-  });
-  return JSON.parse(jwt);
-}
+import { getSession } from './session';
 
 async function refreshTokenHostedLogin(
   ctx: NextPageContext,
@@ -103,10 +89,7 @@ export async function refreshToken(ctx: NextPageContext): Promise<FronteggNextJS
      */
     if (request.url?.startsWith('/_next/')) {
       try {
-        const session = await createGetSession({
-          getCookie: () => CookieManager.getParsedCookieFromRequest(request),
-          cookieResolver: getTokensFromCookieOnEdge,
-        });
+        const session = await getSession(request);
         if (session) {
           return session;
         }


### PR DESCRIPTION
In refresh token https://github.com/frontegg/frontegg-nextjs/pull/169/commits/e052701b199104e6fb75b6b51350d85eec8b62b1
- reuse getSession and remove duplicated code 

 
In createOrGetFronteggApp refactor baseUrl function https://github.com/frontegg/frontegg-nextjs/pull/169/commits/679702cc28a2d460b0cfea912c4d6d7eee73dc24 
 - remove `/oauth/logout` route as its already in authRoute
 -  give clear names 


 
In middleware https://github.com/frontegg/frontegg-nextjs/pull/169/commits/e6ebf0befd738912acb066d13aae8db766f438d2
- create redirectToLogin function and remove all redirect logic from middleware.ts 


 
