### PR TITLE
Update Frontegg AdminPortal to 6.83.0

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "6.81.0",
-    "@frontegg/react-hooks": "6.81.0",
+    "@frontegg/js": "6.82.0",
+    "@frontegg/react-hooks": "6.82.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "6.82.0",
-    "@frontegg/react-hooks": "6.82.0",
+    "@frontegg/js": "6.83.0",
+    "@frontegg/react-hooks": "6.83.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1285,29 +1285,29 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.36.0.tgz#9837f768c03a1e4a30bd304a64fb8844f0e72efe"
   integrity sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==
 
-"@frontegg/js@6.82.0":
-  version "6.82.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.82.0.tgz#926120ed62d5400447b537beaa403b0c7bc5a648"
-  integrity sha512-jwzdCaHVsDn4cwA2FrMTZ3Mcw5vMcZJTjGe7KHSRrLH7Y6tWM4ANb7Kw804BGhLPUMq7AIz0I3gp0rhCy5FJNA==
+"@frontegg/js@6.83.0":
+  version "6.83.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.83.0.tgz#1ff8a4a4430924f811d5bf7436e2665673632174"
+  integrity sha512-Mb8W70bN8KVO75TQk/J64Zm5XDN5wuHIVZZHyogwMBPEfQ3PdOcPAMCsuH7BZ4+/rN6MI05qtkJIr49F+vsjeQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.82.0"
+    "@frontegg/types" "6.83.0"
 
-"@frontegg/react-hooks@6.82.0":
-  version "6.82.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.82.0.tgz#f3aaf0d8bd0710888b13ee7b4c79ec4ea1ce471d"
-  integrity sha512-ZGyk/eqe2XfLlisE7oDBx8IdrpBTtLkfOH+9R6CUiLOpnxYPY5+A7mBDx3iqgFch6aZikyfGu90rTG5RMNSoqQ==
+"@frontegg/react-hooks@6.83.0":
+  version "6.83.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.83.0.tgz#9a15d44c88d0516010d17de7b953cd1d9876b5fa"
+  integrity sha512-FzlXXQ97hsR802h0uQm+vEMR+fDcQlLYCbPnSoYlWKmyU8lZewCb3ZmGX6Tp/MqPwbbPLJwhEfLqZA5nqv6heA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.82.0"
-    "@frontegg/types" "6.82.0"
+    "@frontegg/redux-store" "6.83.0"
+    "@frontegg/types" "6.83.0"
     "@types/react" "*"
     react-redux "^7.x"
 
-"@frontegg/redux-store@6.82.0":
-  version "6.82.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.82.0.tgz#6d11b1745efb3fb2844ac2a4578d9291e0fff1ef"
-  integrity sha512-XWUhewhH00ioNYT2MLFpxna8wQhrrJZ94b6UVezXgywgfOn1LlJf0yfO1G03XTBuqi9GKNzE73g8eHx92ccgaA==
+"@frontegg/redux-store@6.83.0":
+  version "6.83.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.83.0.tgz#0c1056038aaf35521856f087c24c3c71454f15bc"
+  integrity sha512-iGEFkkgv8qqmgWsaKYCVRxwAp7xY46AONrryqoK1mMVJZPW+NfcqzoxcxCb86PqmU0FSEdmoKwEW1uAfcF9lIw==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "^3.0.95"
@@ -1322,13 +1322,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.82.0":
-  version "6.82.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.82.0.tgz#d28e5ee32f00465d61b644e7c3232e30ac18c1b0"
-  integrity sha512-Hd3DhInOO33lG6Ga+mDC/B6jjUQbr9Qww5dpPe34m7EvAe0fSTxIkdd+vBclqrlGSh8ELRos4n22zsI6d/70TA==
+"@frontegg/types@6.83.0":
+  version "6.83.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.83.0.tgz#19260d5e56036e1d91275b5bcd0f9368ede0067c"
+  integrity sha512-ws7xee4DRsF0+7bNlw8Minj/rSG9mH33y2yKb4K0Tq6cNKXDruz7qgcFEXS2zMrGNIWiepipUMBXFYG8w1aBcw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.82.0"
+    "@frontegg/redux-store" "6.83.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1285,29 +1285,29 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.36.0.tgz#9837f768c03a1e4a30bd304a64fb8844f0e72efe"
   integrity sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==
 
-"@frontegg/js@6.81.0":
-  version "6.81.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.81.0.tgz#9f5b40551c216e781b26ddfd997a4bba8166dbf5"
-  integrity sha512-zby1tme7DZrLjML7gyPVtr9ayb4PcPLT0wkSjQSZIZm2EnAsUQVtH0EYLn1mxXhqjKFGKLBPLB+Kkz+PB1xMYQ==
+"@frontegg/js@6.82.0":
+  version "6.82.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.82.0.tgz#926120ed62d5400447b537beaa403b0c7bc5a648"
+  integrity sha512-jwzdCaHVsDn4cwA2FrMTZ3Mcw5vMcZJTjGe7KHSRrLH7Y6tWM4ANb7Kw804BGhLPUMq7AIz0I3gp0rhCy5FJNA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.81.0"
+    "@frontegg/types" "6.82.0"
 
-"@frontegg/react-hooks@6.81.0":
-  version "6.81.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.81.0.tgz#cb71630b72be55bec67d3925c05c628ef34af7ed"
-  integrity sha512-txL7+9MPMPz/R63BBWkN8o6+K/fWl+uJwJ3PM4J7BgSxKfvHSdSDGD97bOFtXtTn20LIpzC6eTIKMyMKlAQhiw==
+"@frontegg/react-hooks@6.82.0":
+  version "6.82.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.82.0.tgz#f3aaf0d8bd0710888b13ee7b4c79ec4ea1ce471d"
+  integrity sha512-ZGyk/eqe2XfLlisE7oDBx8IdrpBTtLkfOH+9R6CUiLOpnxYPY5+A7mBDx3iqgFch6aZikyfGu90rTG5RMNSoqQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.81.0"
-    "@frontegg/types" "6.81.0"
+    "@frontegg/redux-store" "6.82.0"
+    "@frontegg/types" "6.82.0"
     "@types/react" "*"
     react-redux "^7.x"
 
-"@frontegg/redux-store@6.81.0":
-  version "6.81.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.81.0.tgz#85e9783a05b4ea9a3073fa222d6d3f12b4dc763c"
-  integrity sha512-VAso06mTU3cC9il+7VYXeJDiU7Xb94qJrjIzGuYzv+EniIAMRx6HsGDRLA5YHDw8rvKUJw5FSZJw1nhc8Dyijw==
+"@frontegg/redux-store@6.82.0":
+  version "6.82.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.82.0.tgz#6d11b1745efb3fb2844ac2a4578d9291e0fff1ef"
+  integrity sha512-XWUhewhH00ioNYT2MLFpxna8wQhrrJZ94b6UVezXgywgfOn1LlJf0yfO1G03XTBuqi9GKNzE73g8eHx92ccgaA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "^3.0.95"
@@ -1322,13 +1322,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.81.0":
-  version "6.81.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.81.0.tgz#a5dcba77f777bf8d9ed5d978b6b3018ddc558ee6"
-  integrity sha512-2Zqf617EdEPYrkH9qhiBe+aLEro77VzPXL/EeUL2yAXsSOdprRu1uMvsDlmdmUgCDqcsn3p4agUggMUjArIhlA==
+"@frontegg/types@6.82.0":
+  version "6.82.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.82.0.tgz#d28e5ee32f00465d61b644e7c3232e30ac18c1b0"
+  integrity sha512-Hd3DhInOO33lG6Ga+mDC/B6jjUQbr9Qww5dpPe34m7EvAe0fSTxIkdd+vBclqrlGSh8ELRos4n22zsI6d/70TA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.81.0"
+    "@frontegg/redux-store" "6.82.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-11247 - fix version branch 6.82

- FR-11065 - add passkeys mock ff
- FR-11189 - mfa authenticator app change input type
- FR-10821 - fix table color
- FR-11204 - add unit testing with jest
- FR-11139 - fix groups
- FR-11039 - fix groups dummy
- FR-11039 - ff groups
- FR-10530 - fix ff store name
- FR-11067 - error handling on profile image upload
- FR-11039 - extend users table with groups column