### PR TITLE
FR-11538 - support-login-per-tenant-app-directory

### DIFF
--- a/packages/example-app-directory/app/layout.tsx
+++ b/packages/example-app-directory/app/layout.tsx
@@ -6,7 +6,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <head></head>
       <body>
         {/* @ts-expect-error Server Component for more details visit: https://github.com/vercel/next.js/issues/42292 */}
-        <FronteggAppProvider authOptions={{ keepSessionAlive: true }} customLoginOptions={{ paramKey: 'organization' }}>
+        <FronteggAppProvider
+          authOptions={{ keepSessionAlive: true }}
+          customLoginOptions={{ strategy: 'paramKey', paramKey: 'organization' }}
+        >
           {children}
         </FronteggAppProvider>
       </body>

--- a/packages/example-app-directory/app/layout.tsx
+++ b/packages/example-app-directory/app/layout.tsx
@@ -8,7 +8,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         {/* @ts-expect-error Server Component for more details visit: https://github.com/vercel/next.js/issues/42292 */}
         <FronteggAppProvider
           authOptions={{ keepSessionAlive: true }}
-          customLoginOptions={{ strategy: 'paramKey', paramKey: 'organization' }}
+          customLoginOptions={{ paramKey: 'organization' }}
+          hostedLoginBox
         >
           {children}
         </FronteggAppProvider>

--- a/packages/example-app-directory/app/layout.tsx
+++ b/packages/example-app-directory/app/layout.tsx
@@ -6,7 +6,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <head></head>
       <body>
         {/* @ts-expect-error Server Component for more details visit: https://github.com/vercel/next.js/issues/42292 */}
-        <FronteggAppProvider authOptions={{ keepSessionAlive: true }} customLogin={{ paramKey: 'organization' }}>
+        <FronteggAppProvider authOptions={{ keepSessionAlive: true }} customLoginOptions={{ paramKey: 'organization' }}>
           {children}
         </FronteggAppProvider>
       </body>

--- a/packages/example-app-directory/app/layout.tsx
+++ b/packages/example-app-directory/app/layout.tsx
@@ -6,7 +6,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <head></head>
       <body>
         {/* @ts-expect-error Server Component for more details visit: https://github.com/vercel/next.js/issues/42292 */}
-        <FronteggAppProvider authOptions={{ keepSessionAlive: true }}>{children}</FronteggAppProvider>
+        <FronteggAppProvider authOptions={{ keepSessionAlive: true }} customLogin={{ paramKey: 'organization' }}>
+          {children}
+        </FronteggAppProvider>
       </body>
     </html>
   );

--- a/packages/nextjs/src/app/ClientFronteggProvider.tsx
+++ b/packages/nextjs/src/app/ClientFronteggProvider.tsx
@@ -1,16 +1,41 @@
 'use client';
 
-import type { FronteggProviderProps } from '../types';
+import type { ClientFronteggProviderProps } from '../types';
 import { FronteggBaseProvider } from '../common';
 import { useRouter } from 'next/navigation';
-import React, { FC } from 'react';
+import React, { FC, useCallback } from 'react';
 
-export const ClientFronteggProvider: FC<Omit<FronteggProviderProps, 'router'>> = ({ children, basename, ...props }) => {
+export const ClientFronteggProvider: FC<ClientFronteggProviderProps> = ({
+  children,
+  basename,
+  contextOptions,
+  ...props
+}) => {
   const router = useRouter();
   const basePath = process.env.__NEXT_ROUTER_BASEPATH || '';
 
+  const tenantResolver = props.customLogin
+    ? useCallback(() => {
+        const tenantSubdomainIndex = props.customLogin?.subDomainIndex;
+        const tenantParamKey = props.customLogin?.paramKey;
+        if (tenantSubdomainIndex) {
+          return { tenant: window.location.hostname.split('.')[tenantSubdomainIndex] };
+        } else if (tenantParamKey) {
+          const params = new URLSearchParams(window.location.search);
+          const tenant = params.get(tenantParamKey);
+          return { tenant };
+        }
+        return { tenant: null };
+      }, [props.customLogin])
+    : undefined;
+
   return (
-    <FronteggBaseProvider router={router} basename={basename ?? basePath} {...props}>
+    <FronteggBaseProvider
+      router={router}
+      basename={basename ?? basePath}
+      contextOptions={{ ...contextOptions, tenantResolver }}
+      {...props}
+    >
       {children}
     </FronteggBaseProvider>
   );

--- a/packages/nextjs/src/app/ClientFronteggProvider.tsx
+++ b/packages/nextjs/src/app/ClientFronteggProvider.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { ContextOptions } from '@frontegg/rest-api';
 import type { ClientFronteggProviderProps } from '../types';
 import { FronteggBaseProvider } from '../common';
 import { useRouter } from 'next/navigation';
@@ -16,7 +17,10 @@ export const ClientFronteggProvider: FC<ClientFronteggProviderProps> = ({
   const router = useRouter();
   const basePath = process.env.__NEXT_ROUTER_BASEPATH || '';
 
-  const tenantResolver = useMemo(() => createTenantResolverForClientProvider(customLoginOptions), [customLoginOptions]);
+  const tenantResolver = useMemo(
+    () => createTenantResolverForClientProvider(customLoginOptions),
+    [customLoginOptions]
+  ) as ContextOptions['tenantResolver'];
 
   return (
     <FronteggBaseProvider

--- a/packages/nextjs/src/app/ClientFronteggProvider.tsx
+++ b/packages/nextjs/src/app/ClientFronteggProvider.tsx
@@ -3,31 +3,23 @@
 import type { ClientFronteggProviderProps } from '../types';
 import { FronteggBaseProvider } from '../common';
 import { useRouter } from 'next/navigation';
-import React, { FC, useCallback } from 'react';
+import React, { FC, useMemo } from 'react';
+import { createTenantResolverForClientProvider } from './createTenantResolverForClientProvider';
 
 export const ClientFronteggProvider: FC<ClientFronteggProviderProps> = ({
   children,
   basename,
   contextOptions,
+  customLoginOptions,
   ...props
 }) => {
   const router = useRouter();
   const basePath = process.env.__NEXT_ROUTER_BASEPATH || '';
 
-  const tenantResolver = props.customLogin
-    ? useCallback(() => {
-        const tenantSubdomainIndex = props.customLogin?.subDomainIndex;
-        const tenantParamKey = props.customLogin?.paramKey;
-        if (tenantSubdomainIndex) {
-          return { tenant: window.location.hostname.split('.')[tenantSubdomainIndex] };
-        } else if (tenantParamKey) {
-          const params = new URLSearchParams(window.location.search);
-          const tenant = params.get(tenantParamKey);
-          return { tenant };
-        }
-        return { tenant: null };
-      }, [props.customLogin])
-    : undefined;
+  const tenantResolver = useMemo(
+    () => (customLoginOptions ? createTenantResolverForClientProvider(customLoginOptions) : undefined),
+    [customLoginOptions]
+  );
 
   return (
     <FronteggBaseProvider

--- a/packages/nextjs/src/app/ClientFronteggProvider.tsx
+++ b/packages/nextjs/src/app/ClientFronteggProvider.tsx
@@ -16,10 +16,7 @@ export const ClientFronteggProvider: FC<ClientFronteggProviderProps> = ({
   const router = useRouter();
   const basePath = process.env.__NEXT_ROUTER_BASEPATH || '';
 
-  const tenantResolver = useMemo(
-    () => (customLoginOptions ? createTenantResolverForClientProvider(customLoginOptions) : undefined),
-    [customLoginOptions]
-  );
+  const tenantResolver = useMemo(() => createTenantResolverForClientProvider(customLoginOptions), [customLoginOptions]);
 
   return (
     <FronteggBaseProvider

--- a/packages/nextjs/src/app/FronteggAppProvider.tsx
+++ b/packages/nextjs/src/app/FronteggAppProvider.tsx
@@ -1,11 +1,11 @@
 import React, { PropsWithChildren } from 'react';
 import { ClientFronteggProvider } from './ClientFronteggProvider';
-import { FronteggAppOptions } from '@frontegg/types';
 import { getAppHeaders, getAppSession } from './helpers';
 import config from '../config';
 import fetchUserData from '../utils/fetchUserData';
+import { ClientFronteggProviderProps } from '../types';
 
-export type FronteggAppProviderProps = PropsWithChildren<Omit<FronteggAppOptions, 'contextOptions'>>;
+export type FronteggAppProviderProps = PropsWithChildren<Omit<ClientFronteggProviderProps, 'contextOptions'>>;
 
 export const FronteggAppProvider = async (options: FronteggAppProviderProps) => {
   const appEnvConfig = config.appEnvConfig;

--- a/packages/nextjs/src/app/createTenantResolverForClientProvider.ts
+++ b/packages/nextjs/src/app/createTenantResolverForClientProvider.ts
@@ -19,7 +19,7 @@ export const createTenantResolverForClientProvider = (customLoginOptions?: Custo
     try {
       if (isCustomLoginStrategySubDomain(customLoginOptions)) {
         const { subDomainIndex } = customLoginOptions;
-        return { tenant: window.location.hostname.split('.')[subDomainIndex] };
+        return { tenant: window.location.hostname.split('.').slice(0, -2)[subDomainIndex] };
       } else if (isCustomLoginStrategyParamKey(customLoginOptions)) {
         const { paramKey } = customLoginOptions;
         const params = new URLSearchParams(window.location.search);

--- a/packages/nextjs/src/app/createTenantResolverForClientProvider.ts
+++ b/packages/nextjs/src/app/createTenantResolverForClientProvider.ts
@@ -1,0 +1,17 @@
+import { CustomLoginOptionsType } from '../types';
+
+export const createTenantResolverForClientProvider = ({ subDomainIndex, paramKey }: CustomLoginOptionsType) => {
+  if (subDomainIndex && paramKey) {
+    throw new Error('subDomainIndex and paramKey cannot be used together only one strategy is allowed');
+  }
+  return () => {
+    if (subDomainIndex) {
+      return { tenant: window.location.hostname.split('.')[subDomainIndex] };
+    } else if (paramKey) {
+      const params = new URLSearchParams(window.location.search);
+      const tenant = params.get(paramKey);
+      return { tenant };
+    }
+    return { tenant: null };
+  };
+};

--- a/packages/nextjs/src/app/createTenantResolverForClientProvider.ts
+++ b/packages/nextjs/src/app/createTenantResolverForClientProvider.ts
@@ -13,15 +13,19 @@ export const createTenantResolverForClientProvider = (customLoginOptions?: Custo
     return undefined;
   }
   return () => {
-    if (isCustomLoginStrategySubDomain(customLoginOptions)) {
-      const { subDomainIndex } = customLoginOptions;
-      return { tenant: window.location.hostname.split('.')[subDomainIndex] };
-    } else if (isCustomLoginStrategyParamKey(customLoginOptions)) {
-      const { paramKey } = customLoginOptions;
-      const params = new URLSearchParams(window.location.search);
-      const tenant = params.get(paramKey);
-      return { tenant };
+    try {
+      if (isCustomLoginStrategySubDomain(customLoginOptions)) {
+        const { subDomainIndex } = customLoginOptions;
+        return { tenant: window.location.hostname.split('.')[subDomainIndex] };
+      } else if (isCustomLoginStrategyParamKey(customLoginOptions)) {
+        const { paramKey } = customLoginOptions;
+        const params = new URLSearchParams(window.location.search);
+        const tenant = params.get(paramKey);
+        return { tenant };
+      }
+      return {};
+    } catch {
+      return {};
     }
-    return { tenant: null };
   };
 };

--- a/packages/nextjs/src/app/createTenantResolverForClientProvider.ts
+++ b/packages/nextjs/src/app/createTenantResolverForClientProvider.ts
@@ -8,6 +8,7 @@ const isCustomLoginStrategySubDomain = (
   customLoginOptions: CustomLoginOptionsType
 ): customLoginOptions is CustomLoginSubDomainType => customLoginOptions.strategy === 'subDomain';
 
+const emptyTenantResponse = { tenant: null };
 export const createTenantResolverForClientProvider = (customLoginOptions?: CustomLoginOptionsType) => {
   if (!customLoginOptions) {
     return undefined;
@@ -23,9 +24,9 @@ export const createTenantResolverForClientProvider = (customLoginOptions?: Custo
         const tenant = params.get(paramKey);
         return { tenant };
       }
-      return {};
+      return emptyTenantResponse;
     } catch {
-      return {};
+      return emptyTenantResponse;
     }
   };
 };

--- a/packages/nextjs/src/app/createTenantResolverForClientProvider.ts
+++ b/packages/nextjs/src/app/createTenantResolverForClientProvider.ts
@@ -1,34 +1,25 @@
-import { ResolvedTenantResult } from '@frontegg/rest-api';
-import { CustomLoginOptionsType, CustomLoginParamKeyType, CustomLoginSubDomainType } from '../types';
-
-const isCustomLoginStrategyParamKey = (
-  customLoginOptions: CustomLoginOptionsType
-): customLoginOptions is CustomLoginParamKeyType => customLoginOptions.strategy === 'paramKey';
-
-const isCustomLoginStrategySubDomain = (
-  customLoginOptions: CustomLoginOptionsType
-): customLoginOptions is CustomLoginSubDomainType => customLoginOptions.strategy === 'subDomain';
-
-const emptyTenantResponse = {} as ResolvedTenantResult;
+import { CustomLoginOptionsType } from '../types';
 
 export const createTenantResolverForClientProvider = (customLoginOptions?: CustomLoginOptionsType) => {
   if (!customLoginOptions) {
     return undefined;
   }
+
   return () => {
     try {
-      if (isCustomLoginStrategySubDomain(customLoginOptions)) {
-        const { subDomainIndex } = customLoginOptions;
-        return { tenant: window.location.hostname.split('.').slice(0, -2)[subDomainIndex] };
-      } else if (isCustomLoginStrategyParamKey(customLoginOptions)) {
-        const { paramKey } = customLoginOptions;
-        const params = new URLSearchParams(window.location.search);
-        const tenant = params.get(paramKey);
+      const { subDomainIndex, paramKey } = customLoginOptions;
+      if (subDomainIndex) {
+        const tenant = window.location.hostname.split('.').slice(0, -2)[subDomainIndex];
         return { tenant };
       }
-      return emptyTenantResponse;
+      if (paramKey) {
+        const params = new URLSearchParams(window.location.search);
+        const tenant = params.get(paramKey) || undefined;
+        return { tenant };
+      }
+      return { tenant: undefined };
     } catch {
-      return emptyTenantResponse;
+      return { tenant: undefined };
     }
   };
 };

--- a/packages/nextjs/src/app/createTenantResolverForClientProvider.ts
+++ b/packages/nextjs/src/app/createTenantResolverForClientProvider.ts
@@ -1,13 +1,23 @@
-import { CustomLoginOptionsType } from '../types';
+import { CustomLoginOptionsType, CustomLoginParamKeyType, CustomLoginSubDomainType } from '../types';
 
-export const createTenantResolverForClientProvider = ({ subDomainIndex, paramKey }: CustomLoginOptionsType) => {
-  if (subDomainIndex && paramKey) {
-    throw new Error('subDomainIndex and paramKey cannot be used together only one strategy is allowed');
+const isCustomLoginStrategyParamKey = (
+  customLoginOptions: CustomLoginOptionsType
+): customLoginOptions is CustomLoginParamKeyType => customLoginOptions.strategy === 'paramKey';
+
+const isCustomLoginStrategySubDomain = (
+  customLoginOptions: CustomLoginOptionsType
+): customLoginOptions is CustomLoginSubDomainType => customLoginOptions.strategy === 'subDomain';
+
+export const createTenantResolverForClientProvider = (customLoginOptions?: CustomLoginOptionsType) => {
+  if (!customLoginOptions) {
+    return undefined;
   }
   return () => {
-    if (subDomainIndex) {
+    if (isCustomLoginStrategySubDomain(customLoginOptions)) {
+      const { subDomainIndex } = customLoginOptions;
       return { tenant: window.location.hostname.split('.')[subDomainIndex] };
-    } else if (paramKey) {
+    } else if (isCustomLoginStrategyParamKey(customLoginOptions)) {
+      const { paramKey } = customLoginOptions;
       const params = new URLSearchParams(window.location.search);
       const tenant = params.get(paramKey);
       return { tenant };

--- a/packages/nextjs/src/app/createTenantResolverForClientProvider.ts
+++ b/packages/nextjs/src/app/createTenantResolverForClientProvider.ts
@@ -1,3 +1,4 @@
+import { ResolvedTenantResult } from '@frontegg/rest-api';
 import { CustomLoginOptionsType, CustomLoginParamKeyType, CustomLoginSubDomainType } from '../types';
 
 const isCustomLoginStrategyParamKey = (
@@ -8,7 +9,8 @@ const isCustomLoginStrategySubDomain = (
   customLoginOptions: CustomLoginOptionsType
 ): customLoginOptions is CustomLoginSubDomainType => customLoginOptions.strategy === 'subDomain';
 
-const emptyTenantResponse = { tenant: null };
+const emptyTenantResponse = {} as ResolvedTenantResult;
+
 export const createTenantResolverForClientProvider = (customLoginOptions?: CustomLoginOptionsType) => {
   if (!customLoginOptions) {
     return undefined;

--- a/packages/nextjs/src/app/createTenantResolverForClientProvider.ts
+++ b/packages/nextjs/src/app/createTenantResolverForClientProvider.ts
@@ -17,9 +17,9 @@ export const createTenantResolverForClientProvider = (customLoginOptions?: Custo
         const tenant = params.get(paramKey) || undefined;
         return { tenant };
       }
-      return { tenant: undefined };
+      return {};
     } catch {
-      return { tenant: undefined };
+      return {};
     }
   };
 };

--- a/packages/nextjs/src/types/index.ts
+++ b/packages/nextjs/src/types/index.ts
@@ -78,21 +78,23 @@ export interface FronteggProviderProps extends FronteggProviderOptions {
   appName?: string;
 }
 
-export type CustomLoginParamKeyType = {
-  strategy: 'paramKey';
+type CustomLoginOptionsWithParamKeyType = {
   /**
-   *The param key from your tenant login url, for 'https://frontegg.com?organization=[tenant]' would be 'organization';
+   *The param key from your tenant login url, for 'frontegg.com?organization=[tenant]' would be 'organization'
    */
   paramKey: string;
+  subDomainIndex?: never;
 };
-export type CustomLoginSubDomainType = {
-  strategy: 'subDomain';
+
+type CustomLoginOptionsWithSubDomainType = {
   /**
-   *The index of sub domain from your tenant login url, for 'https://[tenant].frontegg.com' would be 0;
+   *The param key from your tenant login url, for 'frontegg.com?organization=[tenant]' would be 'organization'
    */
   subDomainIndex: number;
+  paramKey?: never;
 };
-export type CustomLoginOptionsType = CustomLoginParamKeyType | CustomLoginSubDomainType;
+
+export type CustomLoginOptionsType = CustomLoginOptionsWithParamKeyType | CustomLoginOptionsWithSubDomainType;
 
 type PagesDirectoryProviderProps = {
   customLoginOptions?: CustomLoginOptionsType;

--- a/packages/nextjs/src/types/index.ts
+++ b/packages/nextjs/src/types/index.ts
@@ -78,6 +78,17 @@ export interface FronteggProviderProps extends FronteggProviderOptions {
   appName?: string;
 }
 
+type CustomLoginProps = {
+  paramKey?: string;
+  subDomainIndex?: number;
+};
+
+type PagesDirectoryProviderProps = {
+  customLogin?: CustomLoginProps;
+};
+
+export type ClientFronteggProviderProps = Omit<FronteggProviderProps, 'router'> & PagesDirectoryProviderProps;
+
 declare module 'iron-session' {
   interface IronSessionData {
     accessToken: FronteggNextJSSession['accessToken'];

--- a/packages/nextjs/src/types/index.ts
+++ b/packages/nextjs/src/types/index.ts
@@ -78,22 +78,19 @@ export interface FronteggProviderProps extends FronteggProviderOptions {
   appName?: string;
 }
 
-type CustomLoginProps =
-  | {
-      /**
-       *@param paramKey The param key from your tenant login url, for 'https://frontegg.com?organization=[tenant]' would be 'organization';
-       */
-      paramKey: string;
-    }
-  | {
-      /**
-       *@param subDomainIndex The index of sub domain from your tenant login url, for 'https://[tenant].frontegg.com' would be 0;
-       */
-      subDomainIndex: number;
-    };
+export type CustomLoginOptionsType = {
+  /**
+   *@param paramKey The param key from your tenant login url, for 'https://frontegg.com?organization=[tenant]' would be 'organization';
+   */
+  paramKey?: string;
+  /**
+   *@param subDomainIndex The index of sub domain from your tenant login url, for 'https://[tenant].frontegg.com' would be 0;
+   */
+  subDomainIndex?: number;
+};
 
 type PagesDirectoryProviderProps = {
-  customLogin?: CustomLoginProps;
+  customLoginOptions?: CustomLoginOptionsType;
 };
 
 export type ClientFronteggProviderProps = Omit<FronteggProviderProps, 'router'> & PagesDirectoryProviderProps;

--- a/packages/nextjs/src/types/index.ts
+++ b/packages/nextjs/src/types/index.ts
@@ -88,7 +88,7 @@ type CustomLoginOptionsWithParamKeyType = {
 
 type CustomLoginOptionsWithSubDomainType = {
   /**
-   *The param key from your tenant login url, for 'frontegg.com?organization=[tenant]' would be 'organization'
+   *The index of sub domain from your tenant login url, for 'https://[tenant].frontegg.com' would be 0
    */
   subDomainIndex: number;
   paramKey?: never;

--- a/packages/nextjs/src/types/index.ts
+++ b/packages/nextjs/src/types/index.ts
@@ -81,14 +81,14 @@ export interface FronteggProviderProps extends FronteggProviderOptions {
 export type CustomLoginParamKeyType = {
   strategy: 'paramKey';
   /**
-   *paramKey is the param key from your tenant login url, for 'https://frontegg.com?organization=[tenant]' would be 'organization';
+   *The param key from your tenant login url, for 'https://frontegg.com?organization=[tenant]' would be 'organization';
    */
   paramKey: string;
 };
 export type CustomLoginSubDomainType = {
   strategy: 'subDomain';
   /**
-   *subDomainIndex is the index of sub domain from your tenant login url, for 'https://[tenant].frontegg.com' would be 0;
+   *The index of sub domain from your tenant login url, for 'https://[tenant].frontegg.com' would be 0;
    */
   subDomainIndex: number;
 };

--- a/packages/nextjs/src/types/index.ts
+++ b/packages/nextjs/src/types/index.ts
@@ -81,14 +81,14 @@ export interface FronteggProviderProps extends FronteggProviderOptions {
 export type CustomLoginParamKeyType = {
   strategy: 'paramKey';
   /**
-   *@param paramKey The param key from your tenant login url, for 'https://frontegg.com?organization=[tenant]' would be 'organization';
+   *paramKey is the param key from your tenant login url, for 'https://frontegg.com?organization=[tenant]' would be 'organization';
    */
   paramKey: string;
 };
 export type CustomLoginSubDomainType = {
   strategy: 'subDomain';
   /**
-   *@param subDomainIndex The index of sub domain from your tenant login url, for 'https://[tenant].frontegg.com' would be 0;
+   *subDomainIndex is the index of sub domain from your tenant login url, for 'https://[tenant].frontegg.com' would be 0;
    */
   subDomainIndex: number;
 };

--- a/packages/nextjs/src/types/index.ts
+++ b/packages/nextjs/src/types/index.ts
@@ -78,16 +78,21 @@ export interface FronteggProviderProps extends FronteggProviderOptions {
   appName?: string;
 }
 
-export type CustomLoginOptionsType = {
+export type CustomLoginParamKeyType = {
+  strategy: 'paramKey';
   /**
    *@param paramKey The param key from your tenant login url, for 'https://frontegg.com?organization=[tenant]' would be 'organization';
    */
-  paramKey?: string;
+  paramKey: string;
+};
+export type CustomLoginSubDomainType = {
+  strategy: 'subDomain';
   /**
    *@param subDomainIndex The index of sub domain from your tenant login url, for 'https://[tenant].frontegg.com' would be 0;
    */
-  subDomainIndex?: number;
+  subDomainIndex: number;
 };
+export type CustomLoginOptionsType = CustomLoginParamKeyType | CustomLoginSubDomainType;
 
 type PagesDirectoryProviderProps = {
   customLoginOptions?: CustomLoginOptionsType;

--- a/packages/nextjs/src/types/index.ts
+++ b/packages/nextjs/src/types/index.ts
@@ -78,10 +78,19 @@ export interface FronteggProviderProps extends FronteggProviderOptions {
   appName?: string;
 }
 
-type CustomLoginProps = {
-  paramKey?: string;
-  subDomainIndex?: number;
-};
+type CustomLoginProps =
+  | {
+      /**
+       *@param paramKey The param key from your tenant login url, for 'https://frontegg.com?organization=[tenant]' would be 'organization';
+       */
+      paramKey: string;
+    }
+  | {
+      /**
+       *@param subDomainIndex The index of sub domain from your tenant login url, for 'https://[tenant].frontegg.com' would be 0;
+       */
+      subDomainIndex: number;
+    };
 
 type PagesDirectoryProviderProps = {
   customLogin?: CustomLoginProps;


### PR DESCRIPTION
### support login per tenant in app directory

`FronteggProvider` is a client component and should be used inside layout which is a server component, it is not possible to pass function between server and client because it is not serializable, therefor we cannot pass tenantResolver inside contextOptions and then we cannot use login-per-tenant, this solution should provide support for login per tenant with sub doman and serach param