### PR TITLE
FR-11848 - allow using react hooks in custom components

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@types/node": "^16.18.16",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
+    "@types/react-is": "^17.0.3",
     "babel-loader": "^9.1.2",
     "babel-plugin-module-resolver": "^5.0.0",
     "babel-plugin-optimize-clsx": "^2.6.2",

--- a/packages/nextjs/src/common/CustomComponentHolder.tsx
+++ b/packages/nextjs/src/common/CustomComponentHolder.tsx
@@ -1,0 +1,91 @@
+import React, { FC, isValidElement, ReactElement, useCallback, useMemo, useState } from 'react';
+import ReactDOM from 'react-dom';
+import { FronteggAppInstance } from '@frontegg/types';
+import { isElement } from 'react-is';
+
+export class CustomComponentHolder {
+  private static components: { [name in string]: ReactElement } = {};
+
+  public static set(name: string, element: any) {
+    CustomComponentHolder.components[name] = element;
+  }
+
+  public static get(name: string): ReactElement {
+    return CustomComponentHolder.components[name];
+  }
+}
+
+const overrideValue = (object: any, key: string, value: any) => {
+  const keys: string[] = key.split('.');
+  let iterator = object;
+  while (keys.length > 1) {
+    iterator = iterator[keys.shift() as any];
+  }
+  iterator[keys.shift() as any] = value;
+};
+const Registerer: FC<{ app: FronteggAppInstance; themeKey: string }> = (props) => {
+  const { app, themeKey } = props;
+  const value = CustomComponentHolder.get(themeKey);
+  const [mounted, setMounted] = useState(false);
+
+  const mount = useCallback(() => {
+    setMounted(true);
+  }, []);
+  const unmount = useCallback(() => {
+    setMounted(false);
+  }, []);
+
+  overrideValue(app.options.themeOptions!, themeKey, { type: 'slot', themeKey, mount, unmount });
+
+  let element = app.loginBoxContainer?.querySelector(`[slot="${themeKey}"]`);
+  if (!element && typeof document !== undefined) {
+    element = document.createElement('div');
+    element.slot = themeKey;
+    app.loginBoxContainer?.appendChild(element);
+  }
+
+  return element && mounted ? <React.Fragment>{ReactDOM.createPortal(value, element)}</React.Fragment> : <></>;
+};
+
+export const CustomComponentRegister: FC<{ app: FronteggAppInstance; themeOptions: any }> = ({ app, themeOptions }) => {
+  const keys = useMemo(() => {
+    if (!themeOptions || !themeOptions.loginBox) {
+      return [];
+    }
+    const loop = (key: string, obj: any, keyPath: string): string[] => {
+      if (typeof obj !== 'object' && typeof obj !== 'function') {
+        return [];
+      }
+      if (typeof obj === 'function') {
+        try {
+          obj = React.createElement(obj);
+          if (isValidElement(obj) || isElement(obj)) {
+            const generatedKey = `${keyPath}.${key}`;
+            CustomComponentHolder.set(generatedKey, obj);
+            return [generatedKey];
+          }
+        } catch (e) {}
+      }
+      if (isValidElement(obj) || isElement(obj)) {
+        const generatedKey = `${keyPath}.${key}`;
+        CustomComponentHolder.set(generatedKey, obj);
+        return [generatedKey];
+      } else {
+        const elements: string[] = [];
+        Object.keys(obj).forEach((k) => {
+          elements.push(...loop(k, obj[k], keyPath === '' ? key : `${keyPath}.${key}`));
+        });
+        return elements;
+      }
+    };
+    return loop('loginBox', themeOptions.loginBox, '');
+  }, []);
+
+  return (
+    <>
+      {keys.map((key) => (
+        <Registerer key={key} app={app} themeKey={key} />
+      ))}
+    </>
+  );
+};

--- a/packages/nextjs/src/common/CustomComponentHolder.tsx
+++ b/packages/nextjs/src/common/CustomComponentHolder.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, isValidElement, ReactElement, useCallback, useMemo, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { FronteggAppInstance } from '@frontegg/types';

--- a/packages/nextjs/src/common/FronteggBaseProvider.tsx
+++ b/packages/nextjs/src/common/FronteggBaseProvider.tsx
@@ -8,6 +8,7 @@ import AppContext from './AppContext';
 import initializeFronteggApp from '../utils/initializeFronteggApp';
 import useRequestAuthorizeSSR from './useRequestAuthorizeSSR';
 import useOnRedirectTo from '../utils/useOnRedirectTo';
+import { CustomComponentRegister } from './CustomComponentHolder';
 
 const Connector: FC<FronteggProviderProps> = ({ router, appName = 'default', ...props }) => {
   const isSSR = typeof window === 'undefined';
@@ -38,6 +39,7 @@ const Connector: FC<FronteggProviderProps> = ({ router, appName = 'default', ...
   useRequestAuthorizeSSR({ app, user, tenants, session });
   return (
     <AppContext.Provider value={app}>
+      <CustomComponentRegister app={app} themeOptions={props.themeOptions} />
       <FronteggStoreProvider {...({ ...props, app } as any)}>{props.children}</FronteggStoreProvider>
     </AppContext.Provider>
   );

--- a/packages/nextjs/src/common/FronteggBaseProvider.tsx
+++ b/packages/nextjs/src/common/FronteggBaseProvider.tsx
@@ -39,7 +39,7 @@ const Connector: FC<FronteggProviderProps> = ({ router, appName = 'default', ...
   useRequestAuthorizeSSR({ app, user, tenants, session });
   return (
     <AppContext.Provider value={app}>
-      <CustomComponentRegister app={app} themeOptions={props.themeOptions} />
+      {!isSSR && <CustomComponentRegister app={app} themeOptions={props.themeOptions} />}
       <FronteggStoreProvider {...({ ...props, app } as any)}>{props.children}</FronteggStoreProvider>
     </AppContext.Provider>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3427,6 +3427,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-is@^17.0.3":
+  version "17.0.4"
+  resolved "https://registry.yarnpkg.com/@types/react-is/-/react-is-17.0.4.tgz#3cccd02851f7f7a75b21d6e922da26bc7f8f44ad"
+  integrity sha512-FLzd0K9pnaEvKz4D1vYxK9JmgQPiGk1lu23o1kqGsLeT0iPbRSF7b76+S5T9fD8aRa0B8bY7I/3DebEj+1ysBA==
+  dependencies:
+    "@types/react" "^17"
+
 "@types/react-redux@^7.1.20":
   version "7.1.25"
   resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.25.tgz#de841631205b24f9dfb4967dd4a7901e048f9a88"
@@ -3441,6 +3448,15 @@
   version "18.0.27"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.27.tgz#d9425abe187a00f8a5ec182b010d4fd9da703b71"
   integrity sha512-3vtRKHgVxu3Jp9t718R9BuzoD4NcQ8YJ5XRzsSKxNDiDonD2MXIT1TmSkenxuCycZJoQT5d2vE8LwWJxBC1gmA==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@^17":
+  version "17.0.59"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.59.tgz#5aa4e161a356fcb824d81f166e01bad9e82243bb"
+  integrity sha512-gSON5zWYIGyoBcycCE75E9+r6dCC2dHdsrVkOEiIYNU5+Q28HcBAuqvDuxHcCbMfHBHdeT5Tva/AFn3rnMKE4g==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"


### PR DESCRIPTION
allow using react hooks in custom components

we supported hooks in custom components few months ago in @frontegg/react
Now added it to nextjs because we are not consuming frontegg/react in frontegg/nextjs so we have to maintain in separately :grinning:






