### PR TITLE
Update Frontegg AdminPortal to 6.102.0

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "6.99.0",
-    "@frontegg/react-hooks": "6.99.0",
+    "@frontegg/js": "6.100.0",
+    "@frontegg/react-hooks": "6.100.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "6.100.0",
-    "@frontegg/react-hooks": "6.100.0",
+    "@frontegg/js": "6.101.0",
+    "@frontegg/react-hooks": "6.101.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "6.101.0",
-    "@frontegg/react-hooks": "6.101.0",
+    "@frontegg/js": "6.102.0",
+    "@frontegg/react-hooks": "6.102.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1285,51 +1285,51 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.36.0.tgz#9837f768c03a1e4a30bd304a64fb8844f0e72efe"
   integrity sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==
 
-"@frontegg/js@6.101.0":
-  version "6.101.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.101.0.tgz#591bc26a0777b859f63950bdf7759b7ae6edd565"
-  integrity sha512-maWcG4MdvafUgtpp9Q9MqBbVQwtToKq9IDucXhV3kiKcdrUQOW0S811sS04dUNBmhL4iby+4W2HAiv/bMjRsxg==
+"@frontegg/js@6.102.0":
+  version "6.102.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.102.0.tgz#8d3c36cbdcee575a45241b73a73f8ffd07c0477d"
+  integrity sha512-NWYPqkLVQvJJf0h84fy5SlkNbrNX6op7KSPxYNyCyWflPewQFFnrUEsKDWP3zMQohYXD34jAziQtIOYZFPkONg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.101.0"
+    "@frontegg/types" "6.102.0"
 
-"@frontegg/react-hooks@6.101.0":
-  version "6.101.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.101.0.tgz#a0b1afcfc3b70896ae45056f064309b9785e2458"
-  integrity sha512-PByOBUIeKHpGsJbZwTFPHHMnlsoAULc7DKhdk0BikKHmBrUZM6wT5HZlUSwsGITCRtVsAPYlnBFntFeGU4Y6PQ==
+"@frontegg/react-hooks@6.102.0":
+  version "6.102.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.102.0.tgz#3b5256bfe2359e4c9cfce9569363deae04f8261b"
+  integrity sha512-kDIKOHkEjRsvxV1ukLjIsIICb1FAdBKd05rU4wq9s49iinKZagWRkOBwQUtX7eLM5mNBLSu6OatCpVTXXUmo3g==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.101.0"
-    "@frontegg/types" "6.101.0"
+    "@frontegg/redux-store" "6.102.0"
+    "@frontegg/types" "6.102.0"
     "@types/react" "*"
     get-value "^3.0.1"
     react-redux "^7.x"
 
-"@frontegg/redux-store@6.101.0":
-  version "6.101.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.101.0.tgz#1dc51053555c3e23d8eeaa892ce089b5e21a1338"
-  integrity sha512-50wgknSmyuP5UyvEpoEGh+9Xufld0SjsuURI4NnQu+QVzlC+2XBju07eHcap8E8wa0Zfil2Ve1cH3kYvSGkVzQ==
+"@frontegg/redux-store@6.102.0":
+  version "6.102.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.102.0.tgz#11d12fc7f87a58595542ec79dab06793825c0688"
+  integrity sha512-AqdRaUT3RDYLjlgtdxOMtI1GQLB41AT/Z62q3wxdQG4E9XqvRvNMoJqdo2tCaeyNjTWFzK1YCc+FbiiCkf9Q5g==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/rest-api" "^3.0.110"
+    "@frontegg/rest-api" "^3.0.109"
     "@reduxjs/toolkit" "1.8.5"
     redux-saga "^1.2.1"
     uuid "^8.3.2"
 
-"@frontegg/rest-api@^3.0.110":
+"@frontegg/rest-api@^3.0.109":
   version "3.0.111"
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.111.tgz#a2a337b19812a4fb3c1e7075afb393d9920d027b"
   integrity sha512-GHKm/q/mLNl5cTJDmLk+SNPdLkQ6CrffUdgfH7FWqyVPmgv/ZJVXMao0xcqxTK4qVv3yBLvaUGspz94/VaUbBw==
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.101.0":
-  version "6.101.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.101.0.tgz#d74b23f76087beba1d29bbc55cc177f46ce5e2f1"
-  integrity sha512-qOwqt2qGnxVeXtw02HY5oG6UuJH2qfrZN3k549C+f8p35aKIRbgv0iWXKy/gDJaPzXUnEXLXgOUbMJ8aQjpwkw==
+"@frontegg/types@6.102.0":
+  version "6.102.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.102.0.tgz#8ac161c5187156bca249b3a579cf2ce674d4c248"
+  integrity sha512-GYfNJ6LuPgvTm0/dIVrWvH8Uuu7Lg+lVv4LhxCULhtYsXeN8Ewg9K/t4DkpD3LpbTveJVVmeePtKZywHCY0dUA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.101.0"
+    "@frontegg/redux-store" "6.102.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1285,51 +1285,51 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.36.0.tgz#9837f768c03a1e4a30bd304a64fb8844f0e72efe"
   integrity sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==
 
-"@frontegg/js@6.99.0":
-  version "6.99.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.99.0.tgz#dd703d7b1264ce2a289e482fdc52e5eaf6326db8"
-  integrity sha512-ZXEoGhzEnUMPKCszH1p4sEOiAc8ZOMqNFx8YFQaQroExoFTORgKqvWTpVLmzWrdWmNTj6KnTOK0c3lKwtbXv2w==
+"@frontegg/js@6.100.0":
+  version "6.100.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.100.0.tgz#d0c9d66350556af75300796cde4e274aefb19781"
+  integrity sha512-2BSLsO89BHUkyIgxn3j4jR8h1mnPH/z8unY5CaqVl/uIK+ZSEo70Nw2Sqh2diRZ7KzO7lhntpaCtI3nFaZSdUQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.99.0"
+    "@frontegg/types" "6.100.0"
 
-"@frontegg/react-hooks@6.99.0":
-  version "6.99.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.99.0.tgz#d4f951ccc6fa87dffc8f8da3050b467b79817698"
-  integrity sha512-E1Ppn6KoyPNBN3sE6wWSyQuIymkmtogS78ZcfbcTB7H4npeFQD0fuR/uMzoCxJx5AcMA1f6neDcDLlnHnrTihg==
+"@frontegg/react-hooks@6.100.0":
+  version "6.100.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.100.0.tgz#1881e8a5c6920ccc3729950edde73394fbd7ece8"
+  integrity sha512-dFDiNufPLXErsx9n/l0YEA6nWDIccpV6osu0EyEFx3GULgwWjkerujmBdP3s0eRxITlXFBsYCxZMlbmE551l1Q==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.99.0"
-    "@frontegg/types" "6.99.0"
+    "@frontegg/redux-store" "6.100.0"
+    "@frontegg/types" "6.100.0"
     "@types/react" "*"
     get-value "^3.0.1"
     react-redux "^7.x"
 
-"@frontegg/redux-store@6.99.0":
-  version "6.99.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.99.0.tgz#c661f86d21fa1006c1eb83b7cd9b4ee42a763d4c"
-  integrity sha512-mKwKDfUuXjdFVjBQ/F84HrUX2JLEEF0qxL6xQUUxyYUqasxECY4TZZtkRu7/EeWavlKZWthT7TIdgFTTyigCDg==
+"@frontegg/redux-store@6.100.0":
+  version "6.100.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.100.0.tgz#00c1b47c7fe24b7d90b8179e1b7caa19f369773b"
+  integrity sha512-RVX8hQT2JccEP7HTPfuJBZODMv/ZN9l0kJJXX4ySPbFbnauYNFXe96cv6WSqYPOP5+gPTKH93wBIJ5K4F5lMjQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/rest-api" "^3.0.109"
+    "@frontegg/rest-api" "^3.0.110"
     "@reduxjs/toolkit" "1.8.5"
     redux-saga "^1.2.1"
     uuid "^8.3.2"
 
-"@frontegg/rest-api@^3.0.109":
-  version "3.0.109"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.109.tgz#ee7794d28653b06ba26569271647f5ab9bbe8805"
-  integrity sha512-VCwpyMjPB+I+NLwMXXB8+kFxHRdTVyTzt9BLLcd4EGR4DjCds+0JaStE5vl0FY+utOJUHjRS+IXTD63k4Qm61w==
+"@frontegg/rest-api@^3.0.110":
+  version "3.0.111"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.111.tgz#a2a337b19812a4fb3c1e7075afb393d9920d027b"
+  integrity sha512-GHKm/q/mLNl5cTJDmLk+SNPdLkQ6CrffUdgfH7FWqyVPmgv/ZJVXMao0xcqxTK4qVv3yBLvaUGspz94/VaUbBw==
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.99.0":
-  version "6.99.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.99.0.tgz#117c42e0ca06be460faaf98afb01b25bd8755d2b"
-  integrity sha512-CTEVAnjoxOIRC0hJFbclGO9mro8KejQHBvzllsthKh/lNpc/7A+6w9GkC1dyrWBoXKK4LYYelVo1IESlV+zk9Q==
+"@frontegg/types@6.100.0":
+  version "6.100.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.100.0.tgz#b63a9bbda98494b20e0112ad1022dece39591da2"
+  integrity sha512-VMJAIVKFX1xMw/6obw0/4VjY5oUONVTDqQXdI/UqoHZ/fVNqbeL1RfYI7X5y4kxofhdAhlAtDqdvyeWvD5n0zw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.99.0"
+    "@frontegg/redux-store" "6.100.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1285,30 +1285,30 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.36.0.tgz#9837f768c03a1e4a30bd304a64fb8844f0e72efe"
   integrity sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==
 
-"@frontegg/js@6.100.0":
-  version "6.100.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.100.0.tgz#d0c9d66350556af75300796cde4e274aefb19781"
-  integrity sha512-2BSLsO89BHUkyIgxn3j4jR8h1mnPH/z8unY5CaqVl/uIK+ZSEo70Nw2Sqh2diRZ7KzO7lhntpaCtI3nFaZSdUQ==
+"@frontegg/js@6.101.0":
+  version "6.101.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.101.0.tgz#591bc26a0777b859f63950bdf7759b7ae6edd565"
+  integrity sha512-maWcG4MdvafUgtpp9Q9MqBbVQwtToKq9IDucXhV3kiKcdrUQOW0S811sS04dUNBmhL4iby+4W2HAiv/bMjRsxg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.100.0"
+    "@frontegg/types" "6.101.0"
 
-"@frontegg/react-hooks@6.100.0":
-  version "6.100.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.100.0.tgz#1881e8a5c6920ccc3729950edde73394fbd7ece8"
-  integrity sha512-dFDiNufPLXErsx9n/l0YEA6nWDIccpV6osu0EyEFx3GULgwWjkerujmBdP3s0eRxITlXFBsYCxZMlbmE551l1Q==
+"@frontegg/react-hooks@6.101.0":
+  version "6.101.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.101.0.tgz#a0b1afcfc3b70896ae45056f064309b9785e2458"
+  integrity sha512-PByOBUIeKHpGsJbZwTFPHHMnlsoAULc7DKhdk0BikKHmBrUZM6wT5HZlUSwsGITCRtVsAPYlnBFntFeGU4Y6PQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.100.0"
-    "@frontegg/types" "6.100.0"
+    "@frontegg/redux-store" "6.101.0"
+    "@frontegg/types" "6.101.0"
     "@types/react" "*"
     get-value "^3.0.1"
     react-redux "^7.x"
 
-"@frontegg/redux-store@6.100.0":
-  version "6.100.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.100.0.tgz#00c1b47c7fe24b7d90b8179e1b7caa19f369773b"
-  integrity sha512-RVX8hQT2JccEP7HTPfuJBZODMv/ZN9l0kJJXX4ySPbFbnauYNFXe96cv6WSqYPOP5+gPTKH93wBIJ5K4F5lMjQ==
+"@frontegg/redux-store@6.101.0":
+  version "6.101.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.101.0.tgz#1dc51053555c3e23d8eeaa892ce089b5e21a1338"
+  integrity sha512-50wgknSmyuP5UyvEpoEGh+9Xufld0SjsuURI4NnQu+QVzlC+2XBju07eHcap8E8wa0Zfil2Ve1cH3kYvSGkVzQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "^3.0.110"
@@ -1323,13 +1323,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.100.0":
-  version "6.100.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.100.0.tgz#b63a9bbda98494b20e0112ad1022dece39591da2"
-  integrity sha512-VMJAIVKFX1xMw/6obw0/4VjY5oUONVTDqQXdI/UqoHZ/fVNqbeL1RfYI7X5y4kxofhdAhlAtDqdvyeWvD5n0zw==
+"@frontegg/types@6.101.0":
+  version "6.101.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.101.0.tgz#d74b23f76087beba1d29bbc55cc177f46ce5e2f1"
+  integrity sha512-qOwqt2qGnxVeXtw02HY5oG6UuJH2qfrZN3k549C+f8p35aKIRbgv0iWXKy/gDJaPzXUnEXLXgOUbMJ8aQjpwkw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.100.0"
+    "@frontegg/redux-store" "6.101.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-11887 - Revert Entitlements SDK - Load entitlements list & make the data accessible for the wrappers"

- FR-11722 - fix hosted login with hash [PLEASE DON'T MERGE YET]
- FR-11611 - login per tenant self service small fixes

- FR-11881 - restore search params after closing the admin portal
- FR-11878 - QA fixes for login per tenant self service
- FR-11887 - Entitlements SDK - Load entitlements list & make the data accessible for the wrappers
- FR-11152 - cyprus phone area code 2 fa screen
- FR-11658 - merge 6.99.x
- FR-11652 - Add option to upload metadata file instead of metadata url