### PR TITLE
Update Frontegg AdminPortal to 6.120.0

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "6.119.0",
-    "@frontegg/react-hooks": "6.119.0",
+    "@frontegg/js": "6.120.0",
+    "@frontegg/react-hooks": "6.120.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1285,52 +1285,52 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.36.0.tgz#9837f768c03a1e4a30bd304a64fb8844f0e72efe"
   integrity sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==
 
-"@frontegg/js@6.119.0":
-  version "6.119.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.119.0.tgz#1b1b0c8f6301b79bd71ffb2c79a7a141f5ede4ef"
-  integrity sha512-DVfw6oEzlEI6UvupcKY9wB3eXG9u4VdJ2f6kncdzMrpxGxP+8E3mUfVFYGsODd77smp8DcLitnERNyV+BBU8/g==
+"@frontegg/js@6.120.0":
+  version "6.120.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.120.0.tgz#b39a4dca5b8e53d4ffb1933445a4034f966e02a8"
+  integrity sha512-Z56dnDvu7BW6A+KsZVDexPrxDZHqWRmSRol48y7iAFuxwy/CvMMIvkPyvzvot66LB7r6LV2rOArCpm26QHkP5Q==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.119.0"
+    "@frontegg/types" "6.120.0"
 
-"@frontegg/react-hooks@6.119.0":
-  version "6.119.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.119.0.tgz#2ec4fd46259a85620cc46f10f16e351930b57209"
-  integrity sha512-LR8O8HoF/Jc/NqP6E9XRoKw4zAhcLGh0Aog3SrDm9WnbxJPhtRC1YrLPvxzXXeT3g/lMHChM0mYbyawF0UNxdA==
+"@frontegg/react-hooks@6.120.0":
+  version "6.120.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.120.0.tgz#51b119a4a9cfd773567f9495d747220f81fd01ad"
+  integrity sha512-VX3yKHc/2jVddgAfEdYWBiZd9a2N43kvMME8hZ5PhQaBW6J1UjGjMTYIq7f4bqwY8i8fywJCQNA1day26iL4Ew==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.119.0"
-    "@frontegg/types" "6.119.0"
+    "@frontegg/redux-store" "6.120.0"
+    "@frontegg/types" "6.120.0"
     "@types/react" "*"
     get-value "^3.0.1"
     react-redux "^7.x"
 
-"@frontegg/redux-store@6.119.0":
-  version "6.119.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.119.0.tgz#d4e05b91b9861ca00d1c50041c9871f7f2539a0e"
-  integrity sha512-0vvamVBHgSf50+kTFIE6CoNgKmlI60b79Nb0Nu5FM/Wg/KINqBa49I0KP98W8YXKORQjGIzvGZvVxGemEHz8mg==
+"@frontegg/redux-store@6.120.0":
+  version "6.120.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.120.0.tgz#cb9498bee01f2c2844de6f6a4768431727fd23cb"
+  integrity sha512-lMTbPddt/vMs0httbZsbm1I3sBSF7Vk8l2Iz66GkO+9EQOuy4wg5JOhEubwBo18jzt2WqKjSBu/v8MSz1bTRrw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/rest-api" "3.0.136"
+    "@frontegg/rest-api" "3.0.140"
     "@reduxjs/toolkit" "1.8.5"
     fast-deep-equal "3.1.3"
     redux-saga "^1.2.1"
     uuid "^8.3.2"
 
-"@frontegg/rest-api@3.0.136":
-  version "3.0.136"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.136.tgz#45c0758ea03fd45123cf2be4a6dd14eb587185c5"
-  integrity sha512-Cvr5v36XUrm15XIJ0YptBKSCo1W0INX+UDznjgZfqrWJsbX2xB5ue13yrGPINxvBpixL7D3IlNPtafq/1bnBGA==
+"@frontegg/rest-api@3.0.140":
+  version "3.0.140"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.140.tgz#2bdca4b7f3062c7d05c07d8b92f0600e52368c39"
+  integrity sha512-HVxlJlMrTPZo7BYkaaKx6mrat/LIVgtduU6qWwgzyyrIrElpaM+GI9bqwod/EjrDcJ9qmqf5dvTbncFV4Bm63Q==
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.119.0":
-  version "6.119.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.119.0.tgz#a3bd8ee20fc1c7d2e7be7b1d91d93f359ed32030"
-  integrity sha512-qVjW34hpOjxXI1rthSF6+Ao4VPAEl2Sn9hXqSFXQKid97dZkAhJkhg/rXnZCn632cqiLHAKGJZ3PpHd+NX8h8Q==
+"@frontegg/types@6.120.0":
+  version "6.120.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.120.0.tgz#a3c60ceb80c17abf64960aece93638920fc90816"
+  integrity sha512-aLbJTaVEEAsB4tUvb0mz48fGYxkWS0TGW5tWo+DBZuub+0AlAuVqjfEPd2kr0vDtrJaJBjzz37PxNNtglGhNrg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.119.0"
+    "@frontegg/redux-store" "6.120.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-12114 - Shouldn't show inactive custom social login provider
- FR-12098 - FR-12020 - admin portal user status update if email verification is off + blinking workspace title in admin portal vivid theme
- FR-12660 - implement sagas for security center admin portal
- FR-12664 - Rename redux-saga file to prevent loop imports by webpack
- FR-12652 - init new security page. wrap with ff