### PR TITLE
FR-12745 - reuse react sdk in nextjs sdk

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,7 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "6.123.0",
-    "@frontegg/react-hooks": "6.123.0",
+    "@frontegg/react": "5.0.46",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/src/common/FronteggBaseProvider.tsx
+++ b/packages/nextjs/src/common/FronteggBaseProvider.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React, { FC, useMemo, useRef } from 'react';
-import { FronteggStoreProvider, CustomComponentRegister } from '@frontegg/react-hooks';
+import { FronteggStoreProvider } from '@frontegg/react-hooks';
+import { CustomComponentRegister } from '@frontegg/react';
 import { ContextHolder } from '@frontegg/rest-api';
 import type { FronteggProviderProps } from '../types';
 import AppContext from './AppContext';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1305,10 +1305,18 @@
     get-value "^3.0.1"
     react-redux "^7.x"
 
-"@frontegg/redux-store@6.123.0":
-  version "6.123.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.123.0.tgz#d5030744cd6887867511fa6045fbe48c6c455b44"
-  integrity sha512-WZgRhXmbOgifnC2pcUevVy7q8CPRmrJXGxK52GDdNzK1cxbqIIYEY9wvuS726Lesp6td55coD6Aecs4+8uT9iA==
+"@frontegg/react@5.0.46":
+  version "5.0.46"
+  resolved "https://registry.yarnpkg.com/@frontegg/react/-/react-5.0.46.tgz#98473cae2289f8a00da8f43c5db8e3d380e6cf6d"
+  integrity sha512-exHphHxW/f18F1Y5TOmKCUiNk/BGxzCigBJD/pW7853SFMa+KJ1k05WeV2jYwEdlB3KcwpCH888iL3u+j2dVRg==
+  dependencies:
+    "@frontegg/js" "6.120.0"
+    "@frontegg/react-hooks" "6.120.0"
+
+"@frontegg/redux-store@6.120.0":
+  version "6.120.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.120.0.tgz#cb9498bee01f2c2844de6f6a4768431727fd23cb"
+  integrity sha512-lMTbPddt/vMs0httbZsbm1I3sBSF7Vk8l2Iz66GkO+9EQOuy4wg5JOhEubwBo18jzt2WqKjSBu/v8MSz1bTRrw==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "3.1.5"


### PR DESCRIPTION
reuse react sdk in nextjs sdk 
share custom-component logic between sdks - will be removed to react