### PR TITLE
Update Frontegg AdminPortal to 6.126.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,5 +70,6 @@
   ],
   "workspaces": [
     "packages/*"
-  ]
+  ],
+  "dependencies": {}
 }

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "6.124.0",
-    "@frontegg/react-hooks": "6.124.0",
+    "@frontegg/js": "6.126.0",
+    "@frontegg/react-hooks": "6.126.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1285,52 +1285,52 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.36.0.tgz#9837f768c03a1e4a30bd304a64fb8844f0e72efe"
   integrity sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==
 
-"@frontegg/js@6.124.0":
-  version "6.124.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.124.0.tgz#e16c5b0d0fdc4dc9298b60624fecfd276c4f3c18"
-  integrity sha512-pJagaaj3CEA/gU2qqXZkbhc5rpi+wRGsE0Qu15zTes54/aJQDhSR9JDGPcAPnZZTCqMvHjmLayuYVAIG4H3ERA==
+"@frontegg/js@6.126.0":
+  version "6.126.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.126.0.tgz#3972ec1f8a1cbdace6505f6312186444944e1a32"
+  integrity sha512-mLzDn7dyPDwF098JZ9ET5Co4N6DlLoaBHk9fZ2PS82rIu0DCcuJxWoRrW01aZwXRA00LgJ20UnoeRe39ncbeLA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.124.0"
+    "@frontegg/types" "6.126.0"
 
-"@frontegg/react-hooks@6.124.0":
-  version "6.124.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.124.0.tgz#0e71255a4ae4a6071496fa6e66522681325ef24b"
-  integrity sha512-dr3XzVuyLzD3/FW3slE05Da8eFnzVrfnOygxVNuQJkJmo5GFdxzdAC2TgNaAVUoLWUgyixlCpzpJ3V9YyHPCGg==
+"@frontegg/react-hooks@6.126.0":
+  version "6.126.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.126.0.tgz#0f96570cac28cb38c08b052d232364499419daa1"
+  integrity sha512-K1s839Ns2a8HN8R9ZvDIkqi8WHJHrIm1G9rUDSkpMjAY6JjlisxlSfA07Twj8GQ8vWzQFLghS3QwQOA47lqNmQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.124.0"
-    "@frontegg/types" "6.124.0"
+    "@frontegg/redux-store" "6.126.0"
+    "@frontegg/types" "6.126.0"
     "@types/react" "*"
     get-value "^3.0.1"
     react-redux "^7.x"
 
-"@frontegg/redux-store@6.124.0":
-  version "6.124.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.124.0.tgz#a2b7cd4d1622811511fa972d4419f3665bd34a97"
-  integrity sha512-/D6iQjGH48jm+ImqoRm/eqRz7YkdcV5UvBaOYyGNP+j+k/MKqeFBUlVl2OPFeIYMnZwdEe0eIUCkIzPRet77FQ==
+"@frontegg/redux-store@6.126.0":
+  version "6.126.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.126.0.tgz#b3f35dadfddadf82227bbbe6840440b64c3fe17f"
+  integrity sha512-pOwhHayDQedzlBCWRCgPQnmdYXPlDqeZNDNClgdybqzrxhIfmJY2hUKTE8Eb08DmztpuBlsWYe5xaL2ZjX0sLQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/rest-api" "3.1.5"
+    "@frontegg/rest-api" "3.1.7"
     "@reduxjs/toolkit" "1.8.5"
     fast-deep-equal "3.1.3"
     redux-saga "^1.2.1"
     uuid "^8.3.2"
 
-"@frontegg/rest-api@3.1.5":
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.1.5.tgz#8938923659540a34b66f19a1ac1f2717d310d3ea"
-  integrity sha512-4laNfirbpDxIlXsBKad8InaG0bd8LHn3KP8SVkmSyKzsKPve6lOv1yTYMQdFNCamxP9cw8NDMSoEUrKd9UlsTw==
+"@frontegg/rest-api@3.1.7":
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.1.7.tgz#04d71855d79e32a4fdceecf97950e961d6bb6e44"
+  integrity sha512-gHSn4thztsPTep421sUhkL6icY4CAT9nqf2QpLydiW6OTwVlAVDiFCtTPMpxx+Z2kpK54r8hpkdyDYUY1fSwWQ==
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.124.0":
-  version "6.124.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.124.0.tgz#fbbcfdf1e5021af4951a0f1f94d96a02af1a37c9"
-  integrity sha512-bYYivRaXrd5iZLPtus4OG+XxTRcBxPCl3mdp2tkys5A4TAcFJg+hl9Y+IbsngXe0QzITg0sz4r9/mw4dO1QAmQ==
+"@frontegg/types@6.126.0":
+  version "6.126.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.126.0.tgz#b08cf80aec3cbdec2d1e3175a2e10ab0a2979a64"
+  integrity sha512-gjWr2GCocN1+nO+Ka+Msd/mtH7RCMP/1T4QshWPNuJ1i1Jvex+HhHJ2rXaHjj4XUpTmo6fOTDYmxV8aMAyBqsA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.124.0"
+    "@frontegg/redux-store" "6.126.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 
@@ -4390,15 +4390,10 @@ camelcase@^6.2.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
-caniuse-lite@^1.0.30001406:
-  version "1.0.30001434"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz#ec1ec1cfb0a93a34a0600d37903853030520a4e5"
-  integrity sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA==
-
-caniuse-lite@^1.0.30001449:
-  version "1.0.30001450"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001450.tgz#022225b91200589196b814b51b1bbe45144cf74f"
-  integrity sha512-qMBmvmQmFXaSxexkjjfMvD5rnDL0+m+dUMZKoDYsGG8iZN29RuYh9eRoMvKsT6uMAWlyUUGDEQGJJYjzCIO9ew==
+caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001449:
+  version "1.0.30001517"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001517.tgz"
+  integrity sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==
 
 chalk@4.1.0, chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
- FR-12828 - entitlements api response change
- FR-12224 - support custom login for authenticated users without a tenant alias
- FR-12780 - Entitlements Vanilla JS improvements
- FR-12539 - security score component
- FR-12699 - implement mfa inner page for security center
- FR-12224 - replace admin portal public endpoint
