### PR TITLE
FR-12947 - switching-tenant-cause-duplicated-session-cookie

### DIFF
--- a/packages/nextjs/src/middleware/ProxyResponseCallback.ts
+++ b/packages/nextjs/src/middleware/ProxyResponseCallback.ts
@@ -58,6 +58,7 @@ const ProxyResponseCallback: ProxyResCallback<IncomingMessage, NextApiResponse> 
                   value: session,
                   expires: new Date(decodedJwt.exp * 1000),
                   secure: isSecured,
+                  req,
                 });
                 cookies.push(...sessionCookie);
               }

--- a/packages/nextjs/src/utils/cookies/index.ts
+++ b/packages/nextjs/src/utils/cookies/index.ts
@@ -45,7 +45,7 @@ class CookieManager {
       serializeOptions.sameSite = 'none';
     }
 
-    const serializedCookie = cookieSerializer.serialize(cookieName, cookieValue, serializeOptions);
+    const serializedCookie = cookieSerializer.serialize(this.getCookieName(1), cookieValue, serializeOptions);
 
     if (serializedCookie.length <= COOKIE_MAX_LENGTH) {
       logger.info(`Successfully create a cookie header, '${cookieName}'`);

--- a/packages/nextjs/src/utils/cookies/types.ts
+++ b/packages/nextjs/src/utils/cookies/types.ts
@@ -9,6 +9,7 @@ export interface CreateCookieOptions extends Pick<CookieSerializeOptions, 'domai
   secure: boolean;
   expires: Date;
   silent?: boolean;
+  req?: RequestType;
 }
 
 export interface RemoveCookiesOptions {

--- a/packages/nextjs/src/utils/refreshAccessToken/index.ts
+++ b/packages/nextjs/src/utils/refreshAccessToken/index.ts
@@ -87,6 +87,7 @@ export default async function refreshAccessToken(ctx: NextPageContext): Promise<
       value: session,
       expires: new Date(decodedJwt.exp * 1000),
       secure: isSecured,
+      req: nextJsRequest,
     });
     newSetCookie.push(...cookieValue);
     ctx.res?.setHeader('set-cookie', newSetCookie);


### PR DESCRIPTION
We split the session cookie if its value exceed 4000

we have a problem when switching tenants the cookies size can change and we can split it to different amount of chunks

this can live redundant cookies and in the Imubit case can cause oversized cookie header

the solution is to remove all the cookies before creating new 

### Demo


https://github.com/frontegg/frontegg-nextjs/assets/106734943/eb11062a-c15a-43cd-bd0e-9de76738952d



