### PR TITLE
FR-13274 - Fixed removed cookies in pages directory for next-js version 13.4

### DIFF
--- a/packages/nextjs/src/utils/refreshAccessToken/index.ts
+++ b/packages/nextjs/src/utils/refreshAccessToken/index.ts
@@ -74,8 +74,8 @@ export default async function refreshAccessToken(ctx: NextPageContext): Promise<
 
     const data = await response.json();
 
-    // @ts-ignore
-    const cookieHeader = response.headers?.raw?.()['set-cookie'];
+    // @ts-ignore the first argument "raw" will only work before nextjs 13.4 and the second argument "getSetCookie" will only work after
+    const cookieHeader: string[] = response.headers?.raw?.()['set-cookie'] ?? response.headers?.getSetCookie?.() ?? [];
     const newSetCookie = CookieManager.modifySetCookie(cookieHeader, isSecured) ?? [];
 
     const [session, decodedJwt, refreshToken] = await createSessionFromAccessToken(data);


### PR DESCRIPTION
Customer complained about being sent with a lot of new device emails

After checking it we found out that all the cookies were removed and they had workaround to keep the session cookie.

The reason is we use refreshToken request for every refresh in pages directory and we keep the backend cookies by taking the set-cookie from the request and passing it to the client

We used a deprecated api to fetch the `raw` headers and since next-13.4 it wont work (probably changed node-version).
The fetch api of node-js exposed new functionality that wasn't used before - `getSetCookie` so the fix is using it as a fallback if raw is not working.

Demo of the bug - 

https://github.com/frontegg/frontegg-nextjs/assets/106734943/b62c5ce1-84f6-4b5d-9634-fda07a813412

The fix - 

https://github.com/frontegg/frontegg-nextjs/assets/106734943/4d21c34a-8e1b-419b-9852-1754331e8292


