### PR TITLE
FR-13233 - Device location points out Vercel's IP instead of actual device IP

### DIFF
--- a/packages/nextjs/src/middleware/ProxyRequestCallback.ts
+++ b/packages/nextjs/src/middleware/ProxyRequestCallback.ts
@@ -18,7 +18,7 @@ const logger = fronteggLogger.child({ tag: 'FronteggApiMiddleware.ProxyRequestCa
 const ProxyRequestCallback: ProxyReqCallback<ClientRequest, NextApiRequest> = (proxyReq, req) => {
   try {
     logger.info(`${req.url} | Going to proxy request`);
-    logger.info(`The original req headers are ${req.headers}`);
+    logger.info('The original req headers are', {headers: req.headers});
     logger.debug(`${req.url} | parsing request cookies`);
     const allCookies = CookieManager.parseCookieHeader(req);
     logger.debug(`${req.url} | found ${allCookies} cookies`);

--- a/packages/nextjs/src/middleware/ProxyRequestCallback.ts
+++ b/packages/nextjs/src/middleware/ProxyRequestCallback.ts
@@ -18,6 +18,7 @@ const logger = fronteggLogger.child({ tag: 'FronteggApiMiddleware.ProxyRequestCa
 const ProxyRequestCallback: ProxyReqCallback<ClientRequest, NextApiRequest> = (proxyReq, req) => {
   try {
     logger.info(`${req.url} | Going to proxy request`);
+    logger.info(`The original req headers are ${req.headers}`);
     logger.debug(`${req.url} | parsing request cookies`);
     const allCookies = CookieManager.parseCookieHeader(req);
     logger.debug(`${req.url} | found ${allCookies} cookies`);
@@ -33,7 +34,20 @@ const ProxyRequestCallback: ProxyReqCallback<ClientRequest, NextApiRequest> = (p
     proxyReq.setHeader('x-frontegg-framework', req.headers['x-frontegg-framework'] ?? `next@${NextJsPkg.version}`);
     proxyReq.setHeader('x-frontegg-sdk', req.headers['x-frontegg-sdk'] ?? `@frontegg/nextjs@${sdkVersion.version}`);
     proxyReq.setHeader('x-frontegg-middleware', 'true');
-    proxyReq.setHeader('accept-encoding', 'gzip, deflate, br');
+
+    const xForwardedFor = req.headers['x-forwarded-for'];
+    const xOriginalForwardedFor = req.headers['x-original-forwarded-for'];
+    const cfConnectionIp = req.headers['cf-connecting-ip'];
+
+    if (xForwardedFor) {
+      proxyReq.setHeader('x-forwarded-for', xForwardedFor);
+    }
+    if (xOriginalForwardedFor) {
+      proxyReq.setHeader('x-original-forwarded-for', xOriginalForwardedFor);
+    }
+    if (cfConnectionIp) {
+      proxyReq.setHeader('cf-connecting-ip', cfConnectionIp);
+    }
 
     [
       'x-invoke-path',


### PR DESCRIPTION
Those are the original req headers that we see in a vercel app
<img width="573" alt="image" src="https://github.com/frontegg/frontegg-nextjs/assets/86773508/b79df5ca-c74e-4d82-aca2-6c9e43e57cf4">

We will try to forwarded them  to the proxy req and see how we can manage it in the backend