### PR TITLE
[FOU-2999] FronteggRouter: pass invitationToken to login

### DIFF
--- a/packages/nextjs/src/common/FronteggRouterBase.tsx
+++ b/packages/nextjs/src/common/FronteggRouterBase.tsx
@@ -38,7 +38,8 @@ export function FronteggRouterBase(props: FronteggRouterBaseProps) {
         if (queryParams.redirectUrl) {
           localStorage.setItem(FRONTEGG_AFTER_AUTH_REDIRECT_URL, `${window.location.origin}${queryParams.redirectUrl}`);
         }
-        loginWithRedirect();
+        const payload = queryParams.invitationToken ? { invitationToken: queryParams.invitationToken } : {};
+        loginWithRedirect(payload);
       } else if (pathname === routesObj.logoutUrl) {
         logoutHosted(window.location.origin + window.location.search);
       }

--- a/packages/nextjs/src/common/FronteggRouterBase.tsx
+++ b/packages/nextjs/src/common/FronteggRouterBase.tsx
@@ -38,7 +38,10 @@ export function FronteggRouterBase(props: FronteggRouterBaseProps) {
         if (queryParams.redirectUrl) {
           localStorage.setItem(FRONTEGG_AFTER_AUTH_REDIRECT_URL, `${window.location.origin}${queryParams.redirectUrl}`);
         }
-        const payload = queryParams.invitationToken ? { invitationToken: queryParams.invitationToken } : {};
+        const payload: Record<string, string> = {};
+        if (typeof queryParams.invitationToken === 'string') {
+          payload['invitationToken'] = queryParams.invitationToken;
+        }
         loginWithRedirect(payload);
       } else if (pathname === routesObj.logoutUrl) {
         logoutHosted(window.location.origin + window.location.search);


### PR DESCRIPTION
Passing tenant invite tokens to `loginWithRedirect` through url params (eg. http://localhost:3000/account/login?invitationToken=1223346).

Use case (`middleware.ts`):

```typescript
import { NextResponse } from 'next/server';
import type { NextRequest } from 'next/server';
import { getSessionOnEdge, shouldByPassMiddleware, redirectToLogin } from '@frontegg/nextjs/edge';

export const middleware = async (request: NextRequest) => {
  const pathname = request.nextUrl.pathname;
  const searchParams = request.nextUrl.searchParams;

  if (shouldByPassMiddleware(pathname)) {
    return NextResponse.next();
  }

  const session = await getSessionOnEdge(request);
  if (!session) {
    // eg. http://localhost:3000/private?invitationToken=12233445
    return redirectToLogin(pathname, searchParams);
  }
  return NextResponse.next();
};

export const config = {
  matcher: '/(.*)',
};
```