### PR TITLE
FR-14679 - remove-redundant-env-config-types-from-app-provider

### DIFF
--- a/packages/nextjs/src/app/FronteggAppProvider.tsx
+++ b/packages/nextjs/src/app/FronteggAppProvider.tsx
@@ -6,7 +6,9 @@ import fetchUserData from '../utils/fetchUserData';
 import { ClientFronteggProviderProps } from '../types';
 import { getAppUrlForCustomLoginWithSubdomain } from './getAppUrlForCustomLoginWithSubdomain';
 
-export type FronteggAppProviderProps = PropsWithChildren<Omit<ClientFronteggProviderProps, 'contextOptions'>>;
+export type FronteggAppProviderProps = PropsWithChildren<
+  Omit<ClientFronteggProviderProps, 'contextOptions' | 'envAppUrl' | 'envBaseUrl' | 'envClientId'>
+>;
 
 export const FronteggAppProvider = async (options: FronteggAppProviderProps) => {
   const { envAppUrl, ...appEnvConfig } = config.appEnvConfig;


### PR DESCRIPTION
Because we had to skip type issues related to server components we missed the wrong typing of the app provider.
We made the config app url login Url and clientId required although we take it from env.config