### PR TITLE
FR-14800 - remove app url end char if is /

### DIFF
--- a/packages/nextjs/src/config/index.ts
+++ b/packages/nextjs/src/config/index.ts
@@ -35,7 +35,11 @@ class Config {
   }
 
   get baseUrl(): string {
-    return getEnv(EnvVariables.FRONTEGG_BASE_URL) ?? setupEnvVariables.FRONTEGG_BASE_URL;
+    const baseUrl = getEnv(EnvVariables.FRONTEGG_BASE_URL) ?? setupEnvVariables.FRONTEGG_BASE_URL;
+    if (baseUrl.endsWith('/')) {
+      return baseUrl.slice(0, -1);
+    }
+    return baseUrl;
   }
 
   get baseUrlHost(): string {


### PR DESCRIPTION
We had a customer who provided his baseUrl with the '/' character in the end like this - `https://yuval.frontegg.com/`.
This caused the app to crash and start an infinite loop because all the requests are not sent correctly -
one example - 
<img width="953" alt="image" src="https://github.com/frontegg/frontegg-nextjs/assets/106734943/411fb3ac-790e-4076-ac2a-64c6de172c93">
 
This issue add friction to the integration and makes it event harder
The fix is slicing the last char if variable 