### PR TITLE
FR-14458 - Fixed error on middleware request since NextJs V14.0.2

### DIFF
--- a/packages/nextjs/src/middleware/FronteggProxy.ts
+++ b/packages/nextjs/src/middleware/FronteggProxy.ts
@@ -9,6 +9,7 @@ export const FronteggProxy = createProxyServer({
   target: process.env['FRONTEGG_BASE_URL'],
   changeOrigin: true,
   selfHandleResponse: true,
+  xfwd: true,
 });
 
 /**

--- a/packages/nextjs/src/middleware/FronteggProxy.ts
+++ b/packages/nextjs/src/middleware/FronteggProxy.ts
@@ -9,6 +9,11 @@ export const FronteggProxy = createProxyServer({
   target: process.env['FRONTEGG_BASE_URL'],
   changeOrigin: true,
   selfHandleResponse: true,
+  /**
+   * We set xfwd to true to avoid next-js buggy implementation of x-forwarded-* headers in version 14.0.2
+   * They set the x-forwarded-port header to be 'undefined' in production environment - https://github.com/vercel/next.js/issues/58295
+   * This causes our proxy middleware to fail on every request
+   */
   xfwd: true,
 });
 


### PR DESCRIPTION
We got complaints from customers after upgrading NextJs version from v 14.0.1 to 14.0.2 that oauth/token requests fails only on vercel environment.

After testing it I found that every request that goes through the middleware on vercel env fails with status code 405 with invalid 'undefined' header value 

![image](https://github.com/frontegg/frontegg-nextjs/assets/106734943/34e93b59-e146-435d-a83c-85fbab0bb517)

After deeply investigating the issue, I found that in version 14.0.2, NextJs changed how they handled the `x-forwarded-*` headers in their middleware.
In this pr - https://github.com/vercel/next.js/pull/57815 they set the headers before our middleware.
Because in production env, the customers don’t have a port, the header `x-forwarded-port` is set to `'undefined'`.



<img width="944" alt="image" src="https://github.com/frontegg/frontegg-nextjs/assets/106734943/fd9813ad-8196-4b87-8f21-a421400effa1">



Our http-proxy throws an error for an invalid header `'undefined'` header value for `x-forwarded-port`, and therefore, every request that goes through our middleware crashes.


The fix was to pass the flag `xfwd: true` to override NextJs implementation, 
You can see that they were using this flag as well before removing it in the attached PR.