### PR TITLE
FR-17841- [NextJS] `/refresh` endpoint fails with 400 after switching tenant

### DIFF
--- a/packages/example-pages/pages/index.tsx
+++ b/packages/example-pages/pages/index.tsx
@@ -7,6 +7,13 @@ export function Index() {
   const loginWithRedirect = useLoginWithRedirect();
   const [state, setState] = useState({ userAgent: '', id: -1 });
   const logoutHosted = useLogoutHostedLogin();
+  const { switchTenant } = useAuthActions();
+  const handleTenantSwitch = () => {
+    switchTenant({
+      tenantId: user?.tenantId === 'sso_per_tenant_1' ? 'a4700c12-4119-4add-a7f0-00d31ea279da' : 'sso_per_tenant_1',
+    });
+  };
+  console.log('user', user);
 
   /*
    * Replace the elements below with your own.
@@ -19,6 +26,16 @@ export function Index() {
       <br />
       <br />
       <div>{isAuthenticated ? user?.email : 'not logged in'}</div>
+      <br />
+      <br />
+      <button
+        onClick={() => {
+          handleTenantSwitch();
+        }}
+      >
+        Switch tenant to{' '}
+        {user?.tenantId === 'sso_per_tenant_1' ? 'a4700c12-4119-4add-a7f0-00d31ea279da' : 'sso_per_tenant_1'}
+      </button>
       <br />
       <br />
       <button

--- a/packages/example-pages/pages/index.tsx
+++ b/packages/example-pages/pages/index.tsx
@@ -7,13 +7,6 @@ export function Index() {
   const loginWithRedirect = useLoginWithRedirect();
   const [state, setState] = useState({ userAgent: '', id: -1 });
   const logoutHosted = useLogoutHostedLogin();
-  const { switchTenant } = useAuthActions();
-  const handleTenantSwitch = () => {
-    switchTenant({
-      tenantId: user?.tenantId === 'sso_per_tenant_1' ? 'a4700c12-4119-4add-a7f0-00d31ea279da' : 'sso_per_tenant_1',
-    });
-  };
-  console.log('user', user);
 
   /*
    * Replace the elements below with your own.
@@ -26,16 +19,6 @@ export function Index() {
       <br />
       <br />
       <div>{isAuthenticated ? user?.email : 'not logged in'}</div>
-      <br />
-      <br />
-      <button
-        onClick={() => {
-          handleTenantSwitch();
-        }}
-      >
-        Switch tenant to{' '}
-        {user?.tenantId === 'sso_per_tenant_1' ? 'a4700c12-4119-4add-a7f0-00d31ea279da' : 'sso_per_tenant_1'}
-      </button>
       <br />
       <br />
       <button

--- a/packages/nextjs/src/middleware/ProxyRequestCallback.ts
+++ b/packages/nextjs/src/middleware/ProxyRequestCallback.ts
@@ -63,8 +63,6 @@ const ProxyRequestCallback: ProxyReqCallback<ClientRequest, NextApiRequest> = (p
       'cache-control',
     ].map((header) => proxyReq.removeHeader(header));
 
-    logger.debug(`${req.url} | headers to be sent:`, proxyReq.getHeaders());
-
     logger.debug(`${req.url} | check if request has body`);
     if (req.method !== 'GET' && req.body) {
       logger.debug(`${req.url} | writing request body to proxyReq`);

--- a/packages/nextjs/src/utils/refreshAccessTokenIfNeeded/helpers.ts
+++ b/packages/nextjs/src/utils/refreshAccessTokenIfNeeded/helpers.ts
@@ -5,6 +5,7 @@ import api from '../../api';
 import { getTokensFromCookie } from '../../common';
 import { IncomingMessage } from 'http';
 import config from '../../config';
+import { ApiUrls } from '../../api/urls';
 
 export function hasRefreshTokenCookie(cookies: Record<string, any>): boolean {
   const logger = fronteggLogger.child({ tag: 'refreshToken.hasRefreshTokenCookie' });
@@ -94,4 +95,14 @@ export function isSamlCallback(url: string): boolean {
  */
 export function isSSOPostRequest(url: string): boolean {
   return url === '/frontegg/auth/saml/callback' || url === '/frontegg/auth/oidc/callback';
+}
+
+/**
+ * Checks if the request URL is a refresh token request.
+ * This is used to determine if the current request is targeting
+ * one of the predefined refresh token URLs (embedded or hosted modes).
+ */
+export function isRefreshTokenRequest(url: string): boolean {
+  const refreshTokenUrls = [ApiUrls.refreshToken.embedded, ApiUrls.refreshToken.hosted];
+  return refreshTokenUrls.includes(url);
 }


### PR DESCRIPTION
[FR-17841 - `/refresh` endpoint fails with 400 after switching tenant](https://frontegg.atlassian.net/browse/FR-17841)

When we request a new authorization token, there is no sense to send the old one in the headers and everything works without it
And it was causing an error that wouldn't let you switch between tennants.  Authorization token can be large due to the large number of permissions etc(about 6k chars) and we went over the limits of maximum allowed size of HTTP headers(16k on our side)

Changes:
- remove the Authorization header from /refresh endpoints (embedded and hosted modes)

Before:
https://github.com/user-attachments/assets/fed35f3b-7a63-49fd-b699-f60b280c0dc1


After:
https://github.com/user-attachments/assets/a6541d5d-67e2-4516-b1a8-79d3f3a8bcf1



