### PR TITLE
Add Support for NextJS 15

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-* @aviadmizrachi @frontegg-david @rotemzif1 @amirjaron @MaxArnautFrontegg @TomerFrontegg @raz-shlomo-frontegg @mariavlasov @yuvalotem1 @isra-frontegg @AtaliaRefua @doregg @eran-frontegg @vladFrontegg
+* @aviadmizrachi @frontegg-david @amirjaron @MaxArnautFrontegg @TomerFrontegg @raz-shlomo-frontegg @mariavlasov @doregg @eran-frontegg @vladFrontegg

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-* @aviadmizrachi @frontegg-david @rotemzif1 @amirjaron @MaxArnautFrontegg @TomerFrontegg @raz-shlomo-frontegg @mariavlasov @yuvalotem1 @isra-frontegg @AtaliaRefua @doregg @eran-frontegg
+* @aviadmizrachi @frontegg-david @rotemzif1 @amirjaron @MaxArnautFrontegg @TomerFrontegg @raz-shlomo-frontegg @mariavlasov @yuvalotem1 @isra-frontegg @AtaliaRefua @doregg @eran-frontegg @vladFrontegg

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ and integrate them into their SaaS portals in up to 5 lines of code.
 
 To Add Frontegg to your existing Next.JS project, follow below steps:
 
-1. Use package manager to install Frontegg Next.JS library.
+Use package manager to install Frontegg Next.JS library.
 
    ```bash
      npm install --save @frontegg/nextjs
@@ -41,7 +41,10 @@ To Add Frontegg to your existing Next.JS project, follow below steps:
      yarn add --save @frontegg/nextjs
    ```
 
-2. Wrap the default export with `withFronteggApp` in `./pages/_app.tsx`:
+
+**If you're using the App Directory architecture, you can skip the following Pages architecture steps and refer to the [AppDir guide](#nextjs-appdir-architecture) instead.**
+
+1. Wrap the default export with `withFronteggApp` in `./pages/_app.tsx`:
 
    ```tsx
    // ./pages/_app.tsx
@@ -58,7 +61,7 @@ To Add Frontegg to your existing Next.JS project, follow below steps:
     });
    ```
 
-3. Create files for frontegg middleware under `./pages/api/frontegg/[...frontegg-middleware].ts`:
+2. Create files for frontegg middleware under `./pages/api/frontegg/[...frontegg-middleware].ts`:
 
    ```tsx
    // ./pages/api/frontegg/[...frontegg-middleware].ts
@@ -66,7 +69,7 @@ To Add Frontegg to your existing Next.JS project, follow below steps:
    export { fronteggMiddleware as default } from '@frontegg/nextjs/middleware';
    ```
 
-4. Create placeholder pages for frontegg router under `./pages/[...frontegg-router].tsx`:
+3. Create placeholder pages for frontegg router under `./pages/[...frontegg-router].tsx`:
 
    ```tsx
    // ./pages/[...frontegg-router].tsx
@@ -238,7 +241,7 @@ export const getServerSideProps: GetServerSideProps = withSSRSession(
 );
 ```
 
-## Next.js 13
+## Next.js (AppDir architecture)
 ### wrapping your application
 ```tsx
 // ./app/layout.tsx
@@ -256,9 +259,21 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 }
 ```
 
-### routing
+### Routing
+
+
 ```tsx
 // ./app/[...frontegg-router]/page.tsx
+
+/** 
+ * For Next.js 15+ use the following FronteggAppRouterAsync as default export 
+ */
+export { FronteggAppRouterAsync as default } from '@frontegg/nextjs/app';
+
+
+/** 
+ * For Next.js 14 and below use the following FronteggAppRouter as default export 
+ */
 export { FronteggAppRouter as default } from '@frontegg/nextjs/app';
 ```
 

--- a/packages/example-pages/pages/_app.tsx
+++ b/packages/example-pages/pages/_app.tsx
@@ -7,7 +7,7 @@ function CustomApp({ Component, pageProps }: AppProps) {
 }
 
 const options = {
-  hostedLoginBox: true,
+  hostedLoginBox: false,
   customLoader: true,
   authOptions: {
     keepSessionAlive: true,

--- a/packages/nextjs/src/app/FronteggAppProvider.tsx
+++ b/packages/nextjs/src/app/FronteggAppProvider.tsx
@@ -1,6 +1,6 @@
 import React, { PropsWithChildren } from 'react';
 import { ClientFronteggProvider } from './ClientFronteggProvider';
-import { getAppHeadersPromise, getAppSession } from './helpers';
+import { getAppHeaders, getAppSession } from './helpers';
 import config from '../config';
 import fetchUserData from '../utils/fetchUserData';
 import { ClientFronteggProviderProps } from '../types';
@@ -13,7 +13,7 @@ export type FronteggAppProviderProps = PropsWithChildren<
 
 export const FronteggAppProvider = async (options: FronteggAppProviderProps) => {
   const { envAppUrl, ...appEnvConfig } = config.appEnvConfig;
-  let userData = await fetchUserData({ getSession: getAppSession, getHeaders: getAppHeadersPromise });
+  let userData = await fetchUserData({ getSession: getAppSession, getHeaders: getAppHeaders });
   const subDomainAppUrl = await getAppUrlForCustomLoginWithSubdomain(options.customLoginOptions?.subDomainIndex);
 
   if (process.env['FRONTEGG_SECURE_JWT_ENABLED'] === 'true' && userData) {

--- a/packages/nextjs/src/app/FronteggAppRouter.tsx
+++ b/packages/nextjs/src/app/FronteggAppRouter.tsx
@@ -33,3 +33,32 @@ export function FronteggAppRouter(props: FronteggRouterProps) {
 
   return <FronteggRouterBase pathArr={pathArr} queryParams={searchParams} isAppDirEnabled />;
 }
+
+interface FronteggRouterAsyncProps {
+  params: Promise<ParsedUrlQuery & { 'frontegg-router'?: string[] }>;
+  searchParams?: Promise<ParsedUrlQuery>;
+}
+export async function FronteggAppRouterAsync(props: FronteggRouterAsyncProps) {
+  const params = await props.params;
+  const searchParams = await props.searchParams;
+
+  const pathArr = params['frontegg-router'] || [];
+
+  let pathname = `/${pathArr.join('/')}`;
+  if (!pathname || pathname.startsWith('/_next/data')) {
+    if (searchParams) {
+      const query = searchParams[Object.keys(searchParams)[0]];
+      pathname = `/${Array.isArray(query) ? query.join('/') : query}`;
+    } else {
+      notFound();
+      return null;
+    }
+  }
+
+  if (!isAuthRoute(pathname)) {
+    notFound();
+    return null;
+  }
+
+  return <FronteggRouterBase pathArr={pathArr} queryParams={searchParams} isAppDirEnabled />;
+}

--- a/packages/nextjs/src/app/getAppUrlForCustomLoginWithSubdomain.ts
+++ b/packages/nextjs/src/app/getAppUrlForCustomLoginWithSubdomain.ts
@@ -30,7 +30,7 @@ export const getAppUrlForCustomLoginWithSubdomain = async (subDomainIndex?: numb
     return undefined;
   }
 
-  const headers = getAppHeaders();
+  const headers = await getAppHeaders();
   const alias = getTenantAliasFromHeaders(headers, subDomainIndex);
   if (!alias) {
     resetGlobalCustomLoginAppUrl();

--- a/packages/nextjs/src/app/helpers.ts
+++ b/packages/nextjs/src/app/helpers.ts
@@ -4,24 +4,70 @@ import createSession from '../utils/createSession';
 import encryption from '../utils/encryption';
 import { FronteggUserSession, FronteggUserTokens } from '../types';
 
-const getCookie = () => {
-  const allCookies = cookies().getAll();
+/**
+ * Support for Next.js 15 breaking changes, where props.params is now a promise-based function
+ * for more info: https://nextjs.org/docs/messages/sync-dynamic-apis
+ * @param obj
+ * @param key
+ */
+export async function handleOptionalPromiseObject(obj: any, key: string) {
+  let value;
+
+  if (typeof obj[key] === 'function') {
+    // In case props.params is now a promise-based function
+    value = await obj?.[key]?.();
+  } else {
+    // If props.params is still an object
+    value = obj?.[key];
+  }
+
+  return value;
+}
+
+/**
+ * Support for Next.js 15 breaking changes, where cookies() are now promise-based functions
+ * for more info: https://nextjs.org/docs/messages/sync-dynamic-apis
+ * @param func
+ */
+async function getRequestCookies() {
+  let value = cookies();
+
+  // noinspection SuspiciousTypeOfGuard
+  if (value instanceof Promise) {
+    return await value;
+  }
+  return value;
+}
+
+/**
+ * Support for Next.js 15 breaking changes, where cookies() are now promise-based functions
+ * for more info: https://nextjs.org/docs/messages/sync-dynamic-apis
+ * @param func
+ */
+async function getRequestHeaders() {
+  let value = headers();
+
+  // noinspection SuspiciousTypeOfGuard
+  if (value instanceof Promise) {
+    return await value;
+  }
+  return value;
+}
+
+const getCookie = async () => {
+  const allCookies = (await getRequestCookies()).getAll();
   return CookieManager.parseCookieFromArray(allCookies);
 };
 
-export const getAppSession = () => {
-  const cookies = getCookie();
+export const getAppSession = async () => {
+  const cookies = await getCookie();
   return createSession(cookies, encryption);
 };
 
-export const getAppHeaders = (): Record<string, string> => {
+export const getAppHeaders = async (): Promise<Record<string, string>> => {
   const reqHeaders: Record<string, string> = {};
-  headers().forEach((value, key) => (reqHeaders[key] = value));
+  (await getRequestHeaders()).forEach((value: string, key: string) => (reqHeaders[key] = value));
   return reqHeaders;
-};
-
-export const getAppHeadersPromise = async (): Promise<Record<string, string>> => {
-  return getAppHeaders();
 };
 
 export async function getAppUserSession(): Promise<FronteggUserSession | undefined> {


### PR DESCRIPTION
This PR addresses breaking changes introduced in Next.js 15. To ensure compatibility, we've updated the `next/headers` usage to handle both promise-based (>=15) and non-promise-based (<15) function results.

We’ve also added support for the dynamic router with the `FronteggAppRouterAsync` async server component. In Next.js 15, the `params` and `searchParams` props are returned as promises, which must be awaited.

For Next.js 15 with the App Directory architecture, replace `FronteggAppRouter` with `FronteggAppRouterAsync`:
```javascript
export { FronteggAppRouterAsync as default } from '@frontegg/nextjs/app';
```


**Related issues:** #371