### PR TITLE
FR-18495 - refresh the token when it has expired

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "9.0.5",
+  "version": "9.1.0",
   "npmClient": "yarn",
   "publishConfig": {
     "registry": "https://registry.npmjs.org",

--- a/packages/example-app-directory/package.json
+++ b/packages/example-app-directory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frontegg/example-app-directory",
-  "version": "9.0.5",
+  "version": "9.1.0",
   "private": true,
   "scripts": {
     "clean": "rm -rf  ./node_modules && rm -rf ./.next",

--- a/packages/example-pages/middleware.ts
+++ b/packages/example-pages/middleware.ts
@@ -1,7 +1,12 @@
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { handleSessionOnEdge } from '@frontegg/nextjs/edge';
 
 export const middleware = async (request: NextRequest) => {
+  // this if for frontegg middleware tests
+  if (process.env['FRONTEGG_TEST_URL']) {
+    return NextResponse.next();
+  }
+
   const { pathname, searchParams } = request.nextUrl;
   const headers = request.headers;
 

--- a/packages/example-pages/middleware.ts
+++ b/packages/example-pages/middleware.ts
@@ -24,11 +24,15 @@ export const middleware = async (request: NextRequest) => {
     return NextResponse.next();
   }
 
-  const session = await getSessionOnEdge(request);
-  const response = NextResponse.next();
+  const edgeSession = await getSessionOnEdge(request);
 
-  if (!session) {
+  if (!edgeSession) {
     return redirectToLogin(pathname, searchParams);
+  }
+  if (edgeSession.headers) {
+    return NextResponse.next({
+      headers: edgeSession.headers,
+    });
   }
   return NextResponse.next();
 };

--- a/packages/example-pages/middleware.ts
+++ b/packages/example-pages/middleware.ts
@@ -25,6 +25,8 @@ export const middleware = async (request: NextRequest) => {
   }
 
   const session = await getSessionOnEdge(request);
+  const response = NextResponse.next();
+
   if (!session) {
     return redirectToLogin(pathname, searchParams);
   }

--- a/packages/example-pages/middleware.ts
+++ b/packages/example-pages/middleware.ts
@@ -1,40 +1,13 @@
-import { NextResponse } from 'next/server';
-import type { NextRequest } from 'next/server';
-import {
-  isHostedLoginCallback,
-  handleHostedLoginCallback,
-  getSessionOnEdge,
-  shouldByPassMiddleware,
-  redirectToLogin,
-} from '@frontegg/nextjs/edge';
+import { NextRequest } from 'next/server';
+import { handleSessionOnEdge } from '@frontegg/nextjs/edge';
 
 export const middleware = async (request: NextRequest) => {
-  // this if for frontegg middleware tests
-  if (process.env['FRONTEGG_TEST_URL']) {
-    return NextResponse.next();
-  }
-
   const { pathname, searchParams } = request.nextUrl;
+  const headers = request.headers;
 
-  if (isHostedLoginCallback(pathname, searchParams)) {
-    return handleHostedLoginCallback(request, pathname, searchParams);
-  }
+  // Additional logic if needed
 
-  if (shouldByPassMiddleware(pathname /*, options: optional bypass configuration */)) {
-    return NextResponse.next();
-  }
-
-  const edgeSession = await getSessionOnEdge(request);
-
-  if (!edgeSession) {
-    return redirectToLogin(pathname, searchParams);
-  }
-  if (edgeSession.headers) {
-    return NextResponse.next({
-      headers: edgeSession.headers,
-    });
-  }
-  return NextResponse.next();
+  return handleSessionOnEdge({ request, pathname, searchParams, headers });
 };
 
 export const config = {

--- a/packages/example-pages/package.json
+++ b/packages/example-pages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frontegg/example-pages",
-  "version": "9.0.5",
+  "version": "9.1.0",
   "private": true,
   "scripts": {
     "clean": "rm -rf  ./node_modules && rm -rf ./.next",

--- a/packages/example-pages/pages/index.tsx
+++ b/packages/example-pages/pages/index.tsx
@@ -70,6 +70,9 @@ export function Index() {
       <Link href='/no-ssr'>Go to SSG page</Link>
       <br />
       <br />
+      <Link href='/no-ssr-2'>Go to SSG page 2</Link>
+      <br />
+      <br />
       <Link href='/account/logout'>logout embedded</Link>
       <br />
       <br />

--- a/packages/example-pages/pages/no-ssr-2.tsx
+++ b/packages/example-pages/pages/no-ssr-2.tsx
@@ -1,0 +1,33 @@
+import { AdminPortal, useAuth } from '@frontegg/nextjs';
+import TestComponent from '../components/TestComponent';
+import Link from 'next/link';
+
+export default function NoSsr() {
+  const { user, silentRefreshing = true } = useAuth() as any;
+
+  return (
+    <div>
+      <h1>NO SSR Session</h1>
+
+      {silentRefreshing && <h2>Loading..</h2>}
+      <code>{/*<pre>{JSON.stringify({user}, null, 2)}</pre>*/}</code>
+      {user ? <div>Logged in as: {user.email}</div> : <div>SSG not authorized</div>}
+      <br />
+      <TestComponent />
+      <button
+        onClick={() => {
+          AdminPortal.show();
+        }}
+      >
+        Open AdminPortal
+      </button>
+
+      <br />
+      <br />
+      <br />
+      <Link href='/force-session'>Go to force session page</Link>
+    </div>
+  );
+}
+
+export const getStaticProps = () => ({ props: {} });

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@frontegg/nextjs",
   "libName": "FronteggNextJs",
-  "version": "9.0.5",
+  "version": "9.1.0",
   "author": "Frontegg LTD",
   "license": "MIT",
   "repository": {

--- a/packages/nextjs/src/common/helpers.ts
+++ b/packages/nextjs/src/common/helpers.ts
@@ -1,6 +1,6 @@
 import type { FronteggUserTokens } from '../types';
 import JwtManager from '../utils/jwt';
-import encryptionUtils from '../utils/encryption';
+import encryption from '../utils/encryption';
 
 export async function createSessionFromAccessToken(data: any): Promise<[string, any, string] | []> {
   const accessToken = data.accessToken ?? data.access_token;
@@ -9,7 +9,7 @@ export async function createSessionFromAccessToken(data: any): Promise<[string, 
   decodedJwt.expiresIn = Math.floor((decodedJwt.exp * 1000 - Date.now()) / 1000);
 
   const tokens = { accessToken, refreshToken };
-  const session = await encryptionUtils.sealTokens(tokens, decodedJwt.exp);
+  const session = await encryption.sealTokens(tokens, decodedJwt.exp);
   return [session, decodedJwt, refreshToken];
 }
 
@@ -17,5 +17,5 @@ export async function getTokensFromCookie(cookie?: string): Promise<FronteggUser
   if (!cookie) {
     return undefined;
   }
-  return await encryptionUtils.unsealTokens(cookie);
+  return await encryption.unsealTokens(cookie);
 }

--- a/packages/nextjs/src/edge/refreshAccessTokenIfNeededOnEdge.ts
+++ b/packages/nextjs/src/edge/refreshAccessTokenIfNeededOnEdge.ts
@@ -1,0 +1,112 @@
+import { FronteggEdgeSession } from '../types';
+import type { IncomingMessage } from 'http';
+import CookieManager from '../utils/cookies';
+import config from '../config';
+import api from '../api';
+import fronteggLogger from '../utils/fronteggLogger';
+import JwtManager from '../utils/jwt';
+import encryptionEdge from '../utils/encryption-edge';
+
+const logger = fronteggLogger.child({ tag: 'EdgeRuntime.refreshAccessTokenIfNeededOnEdge' });
+
+export async function refreshAccessTokenIfNeededOnEdge(
+  req: IncomingMessage | Request
+): Promise<FronteggEdgeSession | undefined> {
+  const refreshCookie = CookieManager.getRefreshCookieFromRequestEdge(req);
+  if (!refreshCookie) {
+    logger.info('No refresh cookie found, No session found');
+    return undefined;
+  }
+
+  logger.info('going to refresh token');
+
+  const reqHeaders = req.headers as any as Map<string, string>;
+  const headers: Record<string, string> = {};
+  reqHeaders.forEach((value: string, key: string) => {
+    headers[key] = value;
+  });
+  const clientId = config.clientId;
+  const clientSecret = config.clientSecret;
+
+  let response: Response | null;
+  try {
+    if (config.isHostedLogin) {
+      response = await api.refreshTokenHostedLogin(headers, refreshCookie, clientId, clientSecret);
+    } else {
+      response = await api.refreshTokenEmbedded(headers);
+    }
+  } catch (e) {
+    logger.error('Failed to refresh token', e);
+    return undefined;
+  }
+
+  const isSecured = config.isSSL;
+  if (response === null || !response.ok) {
+    const cookiesToRemove = CookieManager.getRequestCookiesHeaderToRemove({
+      cookieDomain: config.cookieDomain,
+      isSecured,
+      req,
+    });
+    if (cookiesToRemove) {
+      return {
+        session: undefined,
+        headers: {
+          'set-cookie': cookiesToRemove.join(', '),
+        },
+      };
+    }
+    return undefined;
+  }
+
+  const data = await response.json();
+
+  const cookieHeader: string[] =
+    // @ts-ignore the first argument "raw" will only work before nextjs 13.4 and the second argument "getSetCookie" will only work after
+    response.headers?.raw?.()['set-cookie'] ??
+    // @ts-ignore the first argument "raw" will only work before nextjs 13.4 and the second argument "getSetCookie" will only work after
+    response.headers?.getSetCookie?.() ??
+    response.headers?.get?.('set-cookie') ??
+    [];
+
+  const newSetCookie = CookieManager.modifySetCookie(cookieHeader, isSecured) ?? [];
+  const [session, decodedJwt, refreshToken] = await createSessionFromAccessTokenOnEdge(data);
+
+  if (!session) {
+    return {
+      session: undefined,
+      headers: {
+        'set-cookie': newSetCookie.join(', '),
+      },
+    };
+  }
+
+  const cookieValue = CookieManager.create({
+    value: session,
+    expires: new Date(decodedJwt.exp * 1000),
+    secure: isSecured,
+    req,
+  });
+  newSetCookie.push(...cookieValue);
+
+  return {
+    session: {
+      accessToken: data.accessToken ?? data.access_token,
+      user: decodedJwt,
+      refreshToken,
+    },
+    headers: {
+      'set-cookie': newSetCookie.join(', '),
+    },
+  };
+}
+
+export async function createSessionFromAccessTokenOnEdge(data: any): Promise<[string, any, string] | []> {
+  const accessToken = data.accessToken ?? data.access_token;
+  const refreshToken = data.refreshToken ?? data.refresh_token;
+  const { payload: decodedJwt }: any = await JwtManager.verify(accessToken);
+  decodedJwt.expiresIn = Math.floor((decodedJwt.exp * 1000 - Date.now()) / 1000);
+
+  const tokens = { accessToken, refreshToken };
+  const session = await encryptionEdge.sealTokens(tokens, decodedJwt.exp);
+  return [session, decodedJwt, refreshToken];
+}

--- a/packages/nextjs/src/edge/shouldBypassMiddleware.ts
+++ b/packages/nextjs/src/edge/shouldBypassMiddleware.ts
@@ -1,3 +1,5 @@
+import type { NextRequest } from 'next/server';
+
 import { defaultFronteggRoutes } from '../utils/routing';
 
 const staticFilesRegex = new RegExp('^/(_next/static).*');
@@ -25,7 +27,11 @@ interface ByPassOptions {
  * - api/frontegg (API frontegg middleware)
  * - account/[login|logout|saml/callback|...] (frontegg authentication routes)
  */
-export const shouldByPassMiddleware = (pathname: string, options?: ByPassOptions): boolean => {
+export const shouldByPassMiddleware = (
+  pathname: string,
+  headers: NextRequest['headers'],
+  options?: ByPassOptions
+): boolean => {
   const _options = {
     bypassStaticFiles: true,
     bypassImageOptimization: true,
@@ -49,6 +55,12 @@ export const shouldByPassMiddleware = (pathname: string, options?: ByPassOptions
   if (isHeaderRequests) return _options.bypassHeaderRequests;
   if (isFronteggMiddleware) return _options.bypassFronteggMiddleware;
   if (isFronteggRoutes) return _options.bypassFronteggRoutes;
+
+  // noinspection RedundantIfStatementJS
+  if (headers.has('next-router-prefetch') || headers.get('purpose') === 'prefetch') {
+    /** bypass prefetch requests on hovering links that leads to SSG pages **/
+    return true;
+  }
 
   return false;
 };

--- a/packages/nextjs/src/middleware/ProxyResponseCallback.ts
+++ b/packages/nextjs/src/middleware/ProxyResponseCallback.ts
@@ -101,7 +101,7 @@ const ProxyResponseCallback: ProxyResCallback<IncomingMessage, NextApiResponse> 
             res.setHeader(header, `${proxyRes.headers[header]}`);
           });
         res.setHeader('set-cookie', cookies);
-        res.setHeader('content-length', buffer.length);
+        res.setHeader('content-length', Buffer.byteLength(bodyStr));
         res.status(statusCode).end(bodyStr);
       } else {
         if (statusCode >= 400 && statusCode !== 404) {

--- a/packages/nextjs/src/middleware/ProxyResponseCallback.ts
+++ b/packages/nextjs/src/middleware/ProxyResponseCallback.ts
@@ -101,7 +101,7 @@ const ProxyResponseCallback: ProxyResCallback<IncomingMessage, NextApiResponse> 
             res.setHeader(header, `${proxyRes.headers[header]}`);
           });
         res.setHeader('set-cookie', cookies);
-        res.setHeader('content-length', bodyStr.length);
+        res.setHeader('content-length', buffer.length);
         res.status(statusCode).end(bodyStr);
       } else {
         if (statusCode >= 400 && statusCode !== 404) {

--- a/packages/nextjs/src/pages/helpers.ts
+++ b/packages/nextjs/src/pages/helpers.ts
@@ -6,8 +6,15 @@ import config from '../config';
 import CookieManager from '../utils/cookies';
 import createSession from '../utils/createSession';
 import encryption from '../utils/encryption';
+import { hasSetSessionCookie } from '../utils/refreshAccessTokenIfNeeded/helpers';
+import { NextResponse } from 'next/server';
+import { ServerResponse } from 'http';
 
-export const getSession = (req: RequestType) => {
+export const getSession = (req: RequestType, res?: ServerResponse) => {
+  if (res && hasSetSessionCookie(res.getHeader('set-cookie'))) {
+    const cookies = CookieManager.getSessionCookieFromRedirectedResponse(res);
+    return createSession(cookies, encryption);
+  }
   const cookies = CookieManager.getSessionCookieFromRequest(req);
   return createSession(cookies, encryption);
 };
@@ -22,7 +29,7 @@ export function withSSRSession<
   ) => GetServerSidePropsResult<P> | Promise<GetServerSidePropsResult<P>>
 ) {
   return async (context: GetServerSidePropsContext<Q>): Promise<GetServerSidePropsResult<P>> => {
-    const session = await getSession(context.req);
+    const session = await getSession(context.req, context.res);
     if (session) {
       return handler(context, session);
     } else {

--- a/packages/nextjs/src/pages/helpers.ts
+++ b/packages/nextjs/src/pages/helpers.ts
@@ -33,7 +33,7 @@ export function withSSRSession<
     if (session) {
       return handler(context, session);
     } else {
-      let loginUrl = config.authRoutes.loginUrl ?? defaultFronteggRoutes.logoutUrl;
+      let loginUrl = config.authRoutes.loginUrl ?? defaultFronteggRoutes.loginUrl;
 
       if (!loginUrl.startsWith('/')) {
         loginUrl = `/${loginUrl}`;

--- a/packages/nextjs/src/sdkVersion.ts
+++ b/packages/nextjs/src/sdkVersion.ts
@@ -1,1 +1,1 @@
-export default { version: '9.0.5' };
+export default { version: '9.1.0' };

--- a/packages/nextjs/src/types/index.ts
+++ b/packages/nextjs/src/types/index.ts
@@ -20,6 +20,11 @@ export interface FronteggNextJSSession extends FronteggUserTokens {
   user: FronteggUserSession;
 }
 
+export interface FronteggEdgeSession {
+  session?: FronteggNextJSSession;
+  headers?: Record<string, string>;
+}
+
 export type RequestType = IncomingMessage | Request;
 
 export interface AccountEnvironment {
@@ -32,17 +37,13 @@ export interface CustomClaims {
   accountEnvironments: AccountEnvironment[];
 }
 
-export interface FronteggUserTokens {
-  accessToken: string;
-  refreshToken?: string;
-}
-
 export interface AllUserData {
   user?: ILoginResponse | null;
   tenants?: ITenantsResponse[] | null;
   activeTenant?: ITenantsResponse;
   session?: FronteggNextJSSession | null;
 }
+
 export interface FronteggUserSession {
   sub: string;
   name: string;
@@ -60,10 +61,6 @@ export interface FronteggUserSession {
   exp: number;
   aud: string;
   iss: string;
-}
-
-export interface FronteggNextJSSession extends FronteggUserTokens {
-  user: FronteggUserSession;
 }
 
 export interface FronteggProviderOptions extends Omit<FronteggAppOptions, 'contextOptions'>, AllUserData {
@@ -116,6 +113,7 @@ declare module 'iron-session' {
 
 declare global {
   var customLoginAppUrl: string | undefined;
+
   interface ProcessEnv {
     FRONTEGG_BASE_URL: string;
     PORT?: string;

--- a/packages/nextjs/src/utils/cookies/index.ts
+++ b/packages/nextjs/src/utils/cookies/index.ts
@@ -121,17 +121,14 @@ class CookieManager {
 
     logger.debug('Getting cookie header');
     const cookieStr = getCookieHeader(request);
-    logger.debug('cookieStr', cookieStr);
 
     logger.debug('Parsing cookie header string');
     const cookies = cookieSerializer.parse(cookieStr);
-    logger.debug('cookieSerializer.parse(cookieStr)', cookies);
 
     logger.debug('Loop over session cookie headers');
     let i = 1;
     let sessionCookies = '';
     let sessionCookieChunk: string | undefined = cookies[this.getCookieName()];
-    logger.debug('sessionCookieChunk', sessionCookieChunk);
     if (sessionCookieChunk === undefined) {
       do {
         sessionCookieChunk = cookies[getIndexedCookieName(i++)];
@@ -163,7 +160,6 @@ class CookieManager {
 
     logger.debug('Getting cookie header');
     const cookieStr = getCookieHeader(request);
-    logger.debug('cookieStr', cookieStr);
 
     logger.debug('Parsing cookie header string');
     const cookies = cookieSerializer.parse(cookieStr);
@@ -178,7 +174,7 @@ class CookieManager {
       return undefined;
     }
 
-    logger.info(`Refresh cookie found, (${refreshCookie})`);
+    logger.info(`Refresh cookie found for key: ${refreshTokenKey}`);
     return cookies[refreshCookie];
   }
 


### PR DESCRIPTION
This pull request addresses the issue of token expiration by implementing a mechanism to refresh the token when it has expired. The changes include modifications to the authentication middleware to detect expired tokens and initiate a refresh process, ensuring continuous user sessions without unnecessary interruptions. Additionally, the update enhances the application's resilience by handling scenarios where the token cannot be refreshed, prompting a redirect to the login page as needed.