### PR TITLE
Update Frontegg AdminPortal to 7.33.0

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.29.0",
-    "@frontegg/react-hooks": "7.29.0",
+    "@frontegg/js": "7.30.0",
+    "@frontegg/react-hooks": "7.30.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.28.0",
-    "@frontegg/react-hooks": "7.28.0",
+    "@frontegg/js": "7.29.0",
+    "@frontegg/react-hooks": "7.29.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.32.0",
-    "@frontegg/react-hooks": "7.32.0",
+    "@frontegg/js": "7.33.0",
+    "@frontegg/react-hooks": "7.33.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.30.0",
-    "@frontegg/react-hooks": "7.30.0",
+    "@frontegg/js": "7.32.0",
+    "@frontegg/react-hooks": "7.32.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.29.0":
-  version "7.29.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.29.0.tgz#9ecae42797043297873c42e2b83743648698cb85"
-  integrity sha512-KzapCrWZ9oN2lyJIH7OSLVlOkvzWgZDq7wbDKqbaqSVDuYP5E7iSrvJOTvk8rjTEi0MtLdA03ZYKFjhzhNvgHQ==
+"@frontegg/js@7.30.0":
+  version "7.30.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.30.0.tgz#06e8b57218e79f511b967dbc3c13d3ea3ee888f3"
+  integrity sha512-wx6qPlZfINCNhbznKoGr9WMbGfdiK4uPUiLxLH32ku9PRFBZvPexMZuzVeCt+pTtIB1NFIYV/Tkd3/vKIVlizQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.29.0"
+    "@frontegg/types" "7.30.0"
 
-"@frontegg/react-hooks@7.29.0":
-  version "7.29.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.29.0.tgz#d1ded55b650cf2ea779517739b3493a3943455ec"
-  integrity sha512-9rkzDEGHXrKzFmE9V12KL/P5yNxlDLDv27jj5jbsJlSIsPy6aK7f+9Vv2UiXE6Zjb16zfRBAFPDPaetuik+Zig==
+"@frontegg/react-hooks@7.30.0":
+  version "7.30.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.30.0.tgz#44c8a5308446f449b3006d2272feb4cb95beb4e4"
+  integrity sha512-iEubZRJEi6Z8Z39rszRaG3m37ipdMF7vOmQRaYy5a37e7+5/v72pXifmhBYVdNvSiaBQtAFp1Wh2ZZt9nlYHjw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.29.0"
-    "@frontegg/types" "7.29.0"
+    "@frontegg/redux-store" "7.30.0"
+    "@frontegg/types" "7.30.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.29.0":
-  version "7.29.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.29.0.tgz#162bdea5fee6d213a4bc80c4fd0205ff9eafdf13"
-  integrity sha512-CIv0qsXlqTeaTkwth+ktJoAHmoq27pKzDcRmAlbSK4tcd71urhrNBQt8IT48F7riDuHpy8la/rAlY4/HLb+uIA==
+"@frontegg/redux-store@7.30.0":
+  version "7.30.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.30.0.tgz#36baf4728cef51c616265c2f94ff55aa9fdd6843"
+  integrity sha512-FS4p+7eS65IhHO0pMcT9kWwMOwrueiBBmQWLShAtSo6qodE7pQ9ob+kfhXvDI+BDjxRtWR3TCcxmtAXmdySQ5Q==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.29.0"
+    "@frontegg/rest-api" "7.30.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.29.0":
-  version "7.29.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.29.0.tgz#c75d1d7af1d99fe4661ffcd8fd4bf70aa46355a0"
-  integrity sha512-4924B/yph2np4p0qPJASz8KQds2BslpCdVv12UpmUF+CGlSiWitApk1ACEB/lgnVOSE1lYSreZ/zwqruIZS2Gw==
+"@frontegg/rest-api@7.30.0":
+  version "7.30.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.30.0.tgz#a6103b71eae32edffa3ddb096112bf72b55d25e6"
+  integrity sha512-4M/StIUf+CF5334J0CuEHdl0jw7p7z2veRnXlxw+YMo3nK6lfHKtjgIeWM08fCce0d7SFVMed+0GwtvN64IzVg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.29.0":
-  version "7.29.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.29.0.tgz#83b314d62b3127a43a937e5a804a87f534489462"
-  integrity sha512-Iar5oZ3LnrZtOIy1tImjnT/Dx0Ryz5728Syv3IuDaoiGfjkgXFrSH9iyWjPFvgsh8qI3NV+Jh1N+1b+8SzCW+Q==
+"@frontegg/types@7.30.0":
+  version "7.30.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.30.0.tgz#3c9f6ca21bc497adf3fe5802171818cde9b27e2b"
+  integrity sha512-44RGbjh0voOzN1in6LOHwLJ1p04UZyfAFK8mIUMu1+pznBlj9Mxz6lXzz6CTTe4qgJFQEFbeqOSlt9ZyM841Lg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.29.0"
+    "@frontegg/redux-store" "7.30.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.32.0":
-  version "7.32.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.32.0.tgz#bb8be194e72cb41b71f084551fd422e66e7fe869"
-  integrity sha512-2PkW/LUjAMmMAeSqmJamEvT0+p5zHYXRhrpkD5IDe53Zk69sAKbRyES2Spz/CCmJ2BBUHfVjnLwMP2OLvs92Aw==
+"@frontegg/js@7.33.0":
+  version "7.33.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.33.0.tgz#d706a3fa0ae62b2587c9db9a0cdb25e547a4e28f"
+  integrity sha512-v4TRhpW5qe6I2lJF5Unsks6uxIy15US9PgQ8RlJSk1cSV4cegZC95ULl5LH99vWny5BNBs14XrPOHn9KDlATwQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.32.0"
+    "@frontegg/types" "7.33.0"
 
-"@frontegg/react-hooks@7.32.0":
-  version "7.32.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.32.0.tgz#48bfe04e5c5dffa0bcea9eee7e148673d005ebd9"
-  integrity sha512-RNnTdzlfIUIf4acUYFbvP44WVrKFfavAf9Br23JMzq9r9RPiTa2BuFoQkUBjQXIPHrvV024pDCjI3B1kHrd1NA==
+"@frontegg/react-hooks@7.33.0":
+  version "7.33.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.33.0.tgz#bb61eca2aa6c942e2c01a5696f9afca42a48f98e"
+  integrity sha512-H+LTM2K9Ds/txadRjfSuBSLi0bd/tMhT6bmqnGKaHbHyCZaKnLKnNHpkxCB+GrYVq+U6PdTqUNOc4ZUCcQgcxw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.32.0"
-    "@frontegg/types" "7.32.0"
+    "@frontegg/redux-store" "7.33.0"
+    "@frontegg/types" "7.33.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.32.0":
-  version "7.32.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.32.0.tgz#7201732bcd3d668cefde938033c23dbc65e27153"
-  integrity sha512-Kd/h2LvtV1NTGRfarZZR4t5zY9MpruWwRA5N9VKBVmKmwFJz2dxvJkPrPaZJPpIRVJ1+lAAdJWnJOAqwkOKc5w==
+"@frontegg/redux-store@7.33.0":
+  version "7.33.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.33.0.tgz#f3bcaf9f75b0925706be408932278a36ccc6d7cb"
+  integrity sha512-JsQy6JrVq/G1qaoCpH20F+zaejP7cI1ddrSIodaB3G8ppTQp+UpRb5Z78nLcIzt5PLzWYiFzxenpQYUhwTec/w==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.32.0"
+    "@frontegg/rest-api" "7.33.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.32.0":
-  version "7.32.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.32.0.tgz#a03352922fac3297e0eb8dce930ec8abdfd9cb2a"
-  integrity sha512-tetS4yBrQbu0FR9nUfAaty+oucWYWyycAaSa/n7WpzodNcuxgyH1/4JfM2V9JjbTJeZj+XvF5haG+vqYN/KWyw==
+"@frontegg/rest-api@7.33.0":
+  version "7.33.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.33.0.tgz#749c3c797fbab50bb3edf6e98cae1a4e6cff6e84"
+  integrity sha512-2bVYu2uWavRciNHANXylI3scznT62s/B55XxB0VoryIHK8YESO7gqwHdRR+7Snx2rZOXGXt1LPt4P9Y2zi3Oag==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.32.0":
-  version "7.32.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.32.0.tgz#532e8fd1aec5e8d7388e4f69f14b9ddde8036b81"
-  integrity sha512-BLSfXlbeixsLpGrEQxIkcqv9hNWhzOYKg1aL+8pytQuxlAL+95g1B5AJ90CJfKjRH2msButk4R6ZBOeMYw/YnA==
+"@frontegg/types@7.33.0":
+  version "7.33.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.33.0.tgz#ad2f40b380d9f8465fd72e562f07de2f4a3b4139"
+  integrity sha512-CHm/fErdgmR56oGLyuUxaY2RhWcNxs2LvVqyGhP4Jh8LtZhRKcZ9gderChqoaysuFN/la99Z5YqGbeI2UYEuPw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.32.0"
+    "@frontegg/redux-store" "7.33.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.30.0":
-  version "7.30.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.30.0.tgz#06e8b57218e79f511b967dbc3c13d3ea3ee888f3"
-  integrity sha512-wx6qPlZfINCNhbznKoGr9WMbGfdiK4uPUiLxLH32ku9PRFBZvPexMZuzVeCt+pTtIB1NFIYV/Tkd3/vKIVlizQ==
+"@frontegg/js@7.32.0":
+  version "7.32.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.32.0.tgz#bb8be194e72cb41b71f084551fd422e66e7fe869"
+  integrity sha512-2PkW/LUjAMmMAeSqmJamEvT0+p5zHYXRhrpkD5IDe53Zk69sAKbRyES2Spz/CCmJ2BBUHfVjnLwMP2OLvs92Aw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.30.0"
+    "@frontegg/types" "7.32.0"
 
-"@frontegg/react-hooks@7.30.0":
-  version "7.30.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.30.0.tgz#44c8a5308446f449b3006d2272feb4cb95beb4e4"
-  integrity sha512-iEubZRJEi6Z8Z39rszRaG3m37ipdMF7vOmQRaYy5a37e7+5/v72pXifmhBYVdNvSiaBQtAFp1Wh2ZZt9nlYHjw==
+"@frontegg/react-hooks@7.32.0":
+  version "7.32.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.32.0.tgz#48bfe04e5c5dffa0bcea9eee7e148673d005ebd9"
+  integrity sha512-RNnTdzlfIUIf4acUYFbvP44WVrKFfavAf9Br23JMzq9r9RPiTa2BuFoQkUBjQXIPHrvV024pDCjI3B1kHrd1NA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.30.0"
-    "@frontegg/types" "7.30.0"
+    "@frontegg/redux-store" "7.32.0"
+    "@frontegg/types" "7.32.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.30.0":
-  version "7.30.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.30.0.tgz#36baf4728cef51c616265c2f94ff55aa9fdd6843"
-  integrity sha512-FS4p+7eS65IhHO0pMcT9kWwMOwrueiBBmQWLShAtSo6qodE7pQ9ob+kfhXvDI+BDjxRtWR3TCcxmtAXmdySQ5Q==
+"@frontegg/redux-store@7.32.0":
+  version "7.32.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.32.0.tgz#7201732bcd3d668cefde938033c23dbc65e27153"
+  integrity sha512-Kd/h2LvtV1NTGRfarZZR4t5zY9MpruWwRA5N9VKBVmKmwFJz2dxvJkPrPaZJPpIRVJ1+lAAdJWnJOAqwkOKc5w==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.30.0"
+    "@frontegg/rest-api" "7.32.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.30.0":
-  version "7.30.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.30.0.tgz#a6103b71eae32edffa3ddb096112bf72b55d25e6"
-  integrity sha512-4M/StIUf+CF5334J0CuEHdl0jw7p7z2veRnXlxw+YMo3nK6lfHKtjgIeWM08fCce0d7SFVMed+0GwtvN64IzVg==
+"@frontegg/rest-api@7.32.0":
+  version "7.32.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.32.0.tgz#a03352922fac3297e0eb8dce930ec8abdfd9cb2a"
+  integrity sha512-tetS4yBrQbu0FR9nUfAaty+oucWYWyycAaSa/n7WpzodNcuxgyH1/4JfM2V9JjbTJeZj+XvF5haG+vqYN/KWyw==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.30.0":
-  version "7.30.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.30.0.tgz#3c9f6ca21bc497adf3fe5802171818cde9b27e2b"
-  integrity sha512-44RGbjh0voOzN1in6LOHwLJ1p04UZyfAFK8mIUMu1+pznBlj9Mxz6lXzz6CTTe4qgJFQEFbeqOSlt9ZyM841Lg==
+"@frontegg/types@7.32.0":
+  version "7.32.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.32.0.tgz#532e8fd1aec5e8d7388e4f69f14b9ddde8036b81"
+  integrity sha512-BLSfXlbeixsLpGrEQxIkcqv9hNWhzOYKg1aL+8pytQuxlAL+95g1B5AJ90CJfKjRH2msButk4R6ZBOeMYw/YnA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.30.0"
+    "@frontegg/redux-store" "7.32.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.28.0":
-  version "7.28.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.28.0.tgz#6abb2678bcbe5af4e062dd95a9e55ec31b256e81"
-  integrity sha512-USZiGXs2A2GnrAMYg9d3aOxB/ILeg8B8IOI/555ZjT3vj8jby45J4UAnOYFwt02UKFVTV9orQNIPtLqApa7i3w==
+"@frontegg/js@7.29.0":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.29.0.tgz#9ecae42797043297873c42e2b83743648698cb85"
+  integrity sha512-KzapCrWZ9oN2lyJIH7OSLVlOkvzWgZDq7wbDKqbaqSVDuYP5E7iSrvJOTvk8rjTEi0MtLdA03ZYKFjhzhNvgHQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.28.0"
+    "@frontegg/types" "7.29.0"
 
-"@frontegg/react-hooks@7.28.0":
-  version "7.28.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.28.0.tgz#514fe4d2f9b4f6670c680e04411b5f8f892361f3"
-  integrity sha512-fBVP0CbFLJ4AZ6AxVzz6cY+6YStFAycsMRQMZjMcAhYEr0580j43iWzrHOS0xU42BMp3MB8ECykcPENj5GoLww==
+"@frontegg/react-hooks@7.29.0":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.29.0.tgz#d1ded55b650cf2ea779517739b3493a3943455ec"
+  integrity sha512-9rkzDEGHXrKzFmE9V12KL/P5yNxlDLDv27jj5jbsJlSIsPy6aK7f+9Vv2UiXE6Zjb16zfRBAFPDPaetuik+Zig==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.28.0"
-    "@frontegg/types" "7.28.0"
+    "@frontegg/redux-store" "7.29.0"
+    "@frontegg/types" "7.29.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.28.0":
-  version "7.28.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.28.0.tgz#41d55ad08a6062f8d0251ae84ad6a95382bf7d34"
-  integrity sha512-vRGb8R07hsc8ghuYZi8YnHun2aH6ph9IYQixF8S/XEC3ucqwBKfpjxHKH37Hzbx8VuxT+bNLgHxthQedWH2/cw==
+"@frontegg/redux-store@7.29.0":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.29.0.tgz#162bdea5fee6d213a4bc80c4fd0205ff9eafdf13"
+  integrity sha512-CIv0qsXlqTeaTkwth+ktJoAHmoq27pKzDcRmAlbSK4tcd71urhrNBQt8IT48F7riDuHpy8la/rAlY4/HLb+uIA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.28.0"
+    "@frontegg/rest-api" "7.29.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.28.0":
-  version "7.28.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.28.0.tgz#fee670ec62567dda1b4f90c2272a825057a10c0c"
-  integrity sha512-Ab2DWv7Hb+A+x/onUaGwJW1lkqwEPYZicAkV8A1ZE8B5kFHptVG6xviqfTzbCT/jiB/PpEYtMCmIBbseiB10zw==
+"@frontegg/rest-api@7.29.0":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.29.0.tgz#c75d1d7af1d99fe4661ffcd8fd4bf70aa46355a0"
+  integrity sha512-4924B/yph2np4p0qPJASz8KQds2BslpCdVv12UpmUF+CGlSiWitApk1ACEB/lgnVOSE1lYSreZ/zwqruIZS2Gw==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.28.0":
-  version "7.28.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.28.0.tgz#fb37d4d66306e33cbae22a886a65df85a9a6edc9"
-  integrity sha512-SyPQpDS2NxxZWh6t2/lVjPlfPlvBxArblFAicSrGOwmfBvtsgjK/zrNIDDyZ1Hohh76zS7Uw/S/kQO5DXMJRoQ==
+"@frontegg/types@7.29.0":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.29.0.tgz#83b314d62b3127a43a937e5a804a87f534489462"
+  integrity sha512-Iar5oZ3LnrZtOIy1tImjnT/Dx0Ryz5728Syv3IuDaoiGfjkgXFrSH9iyWjPFvgsh8qI3NV+Jh1N+1b+8SzCW+Q==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.28.0"
+    "@frontegg/redux-store" "7.29.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-18699 - Removed entitlements automatic 30 seconds refresh mechanism
- FR-18138 - Added logic to improve login box and admin portal stability and resiliency
- FR-18646 - Fixed missing permissions with wildcard on custom roles
- FR-18341 - Fixed Google Chrome Translate feature causes a crash
- FR-16902 - Fixed login box scroll on mobile browsers
