### PR TITLE
Deprecate getSessionOnEdge with backward compatibility

### DIFF
--- a/packages/nextjs/src/app/FronteggAppProvider.tsx
+++ b/packages/nextjs/src/app/FronteggAppProvider.tsx
@@ -6,6 +6,8 @@ import fetchUserData from '../utils/fetchUserData';
 import { ClientFronteggProviderProps } from '../types';
 import { getAppUrlForCustomLoginWithSubdomain } from './getAppUrlForCustomLoginWithSubdomain';
 import { removeJwtSignatureFrom } from '../middleware/helpers';
+import fronteggLogger from '../utils/fronteggLogger';
+import { FRONTEGG_HOSTED_LOGIN_MIGRATION_WARNING } from './consts';
 
 export type FronteggAppProviderProps = PropsWithChildren<
   Omit<ClientFronteggProviderProps, 'contextOptions' | 'envAppUrl' | 'envBaseUrl' | 'envClientId'>
@@ -15,17 +17,23 @@ export const FronteggAppProvider = async (options: FronteggAppProviderProps) => 
   const { envAppUrl, ...appEnvConfig } = config.appEnvConfig;
   let userData = await fetchUserData({ getSession: getAppSession, getHeaders: getAppHeaders });
   const subDomainAppUrl = await getAppUrlForCustomLoginWithSubdomain(options.customLoginOptions?.subDomainIndex);
+  const logger = fronteggLogger.child({ tag: 'FronteggAppProvider' });
 
   if (process.env['FRONTEGG_SECURE_JWT_ENABLED'] === 'true' && userData) {
     userData = removeJwtSignatureFrom(userData);
     userData.session = removeJwtSignatureFrom(userData?.session);
   }
+  if (Object.hasOwn(options, 'hostedLoginBox')) {
+    logger.warn(FRONTEGG_HOSTED_LOGIN_MIGRATION_WARNING);
+  }
+
   const providerProps = {
     ...appEnvConfig,
     ...userData,
     ...options,
     envAppUrl: subDomainAppUrl ?? envAppUrl,
     secureJwtEnabled: options.secureJwtEnabled ?? false,
+    hostedLoginBox: appEnvConfig.envHostedLoginBox ?? options.hostedLoginBox ?? false,
   };
 
   return <ClientFronteggProvider {...providerProps} />;

--- a/packages/nextjs/src/app/consts.ts
+++ b/packages/nextjs/src/app/consts.ts
@@ -1,0 +1,1 @@
+export const FRONTEGG_HOSTED_LOGIN_MIGRATION_WARNING = `\n**Deprecated**: The 'hostedLoginBox' prop is deprecated in frontegg NextJS SKD and will be removed in the next major version. Please use 'FRONTEGG_HOSTED_LOGIN' environment variable instead.`;

--- a/packages/nextjs/src/edge/getSessionOnEdge.ts
+++ b/packages/nextjs/src/edge/getSessionOnEdge.ts
@@ -1,5 +1,5 @@
 import type { IncomingMessage } from 'http';
-import { FronteggEdgeSession } from '../types';
+import { FronteggEdgeSession, FronteggNextJSSession } from '../types';
 import CookieManager from '../utils/cookies';
 import createSession from '../utils/createSession';
 import encryptionEdge from '../utils/encryption-edge';
@@ -93,8 +93,10 @@ Alternatively, to manually verify the session, you can use checkSessionOnEdge. N
  * ```
  * @deprecated
  */
-export const getSessionOnEdge = async (req: IncomingMessage | Request): Promise<FronteggEdgeSession | undefined> => {
-  throw new Error(GET_SESSION_ON_EDGE_DEPRECATED_ERROR);
+
+export const getSessionOnEdge = (req: IncomingMessage | Request): Promise<FronteggNextJSSession | undefined> => {
+  const cookies = CookieManager.getSessionCookieFromRequest(req);
+  return createSession(cookies, encryptionEdge);
 };
 
 /**

--- a/packages/nextjs/src/edge/refreshAccessTokenIfNeededOnEdge.ts
+++ b/packages/nextjs/src/edge/refreshAccessTokenIfNeededOnEdge.ts
@@ -88,6 +88,12 @@ export async function refreshAccessTokenIfNeededOnEdge(
   });
   newSetCookie.push(...cookieValue);
 
+  const forwardedHeaders = req.headers as Headers;
+  newSetCookie.forEach((cookie) => {
+    // get cookie name and value only
+    const [name, value] = cookie.split(';')[0].split('=');
+    forwardedHeaders.set('cookie', `${name}=${value}`);
+  });
   return {
     session: {
       accessToken: data.accessToken ?? data.access_token,
@@ -97,6 +103,7 @@ export async function refreshAccessTokenIfNeededOnEdge(
     headers: {
       'set-cookie': newSetCookie.join(', '),
     },
+    forwardedHeaders,
   };
 }
 

--- a/packages/nextjs/src/types/index.ts
+++ b/packages/nextjs/src/types/index.ts
@@ -23,6 +23,7 @@ export interface FronteggNextJSSession extends FronteggUserTokens {
 export interface FronteggEdgeSession {
   session?: FronteggNextJSSession;
   headers?: Record<string, string>;
+  forwardedHeaders?: Headers;
 }
 
 export type RequestType = IncomingMessage | Request;


### PR DESCRIPTION
- Deprecate getSessionOnEdge with warning instead of throwing error
- Resolve issue related to the AppDir architecture that the new cookies were not being forwarded to the server component after refreshing the token in the middleware.