### PR TITLE
Update Frontegg AdminPortal to 7.75.0

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.74.0",
-    "@frontegg/react-hooks": "7.74.0",
+    "@frontegg/js": "7.75.0",
+    "@frontegg/react-hooks": "7.75.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.71.0",
-    "@frontegg/react-hooks": "7.71.0",
+    "@frontegg/js": "7.72.0",
+    "@frontegg/react-hooks": "7.72.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.72.0",
-    "@frontegg/react-hooks": "7.72.0",
+    "@frontegg/js": "7.73.0",
+    "@frontegg/react-hooks": "7.73.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.73.0",
-    "@frontegg/react-hooks": "7.73.0",
+    "@frontegg/js": "7.74.0",
+    "@frontegg/react-hooks": "7.74.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.72.0":
-  version "7.72.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.72.0.tgz#8da75af948b45df89a13974c87e028a8372c0b4a"
-  integrity sha512-GQ0TJ4Qly6MUmBuF0fm6ZZz4pebXbVlX0sqZFJMPqDjmGn29HuYUF1y9N8LEC8NACeUgl9ctvPse0ObMe6y/IA==
+"@frontegg/js@7.73.0":
+  version "7.73.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.73.0.tgz#f1466733ca2fd9a72cd393e026dac922fea70d0f"
+  integrity sha512-en4odN4xYCk+sVXbsvgcMCZPpd+iCvyQa9sur2nu08chNGEqkHoL9vqSvCpHsp9cYJyX7nWlmLCvFsAUeEkgMA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.72.0"
+    "@frontegg/types" "7.73.0"
 
-"@frontegg/react-hooks@7.72.0":
-  version "7.72.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.72.0.tgz#e735fb5a7e3fffdfbc4afe278e4da4244c2e3c92"
-  integrity sha512-GEwdENAghmrre7ZyASVPt5vuTMIJ5y2lUK+oylx4eJdkBNyjVvS3xEtQdBg0BuwszNzxrbN34c1olZZE8j5xTw==
+"@frontegg/react-hooks@7.73.0":
+  version "7.73.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.73.0.tgz#90c0b484793e696976cc5da1bcbe859e3755cc11"
+  integrity sha512-yvYE1PGgWKMlKPO7bsK0DCVJmGwzjLz+l5NnolKrtbWcAKcqV6qgkp73igljkOd8tYWtyiotqP36Y/5G/tyWrA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.72.0"
-    "@frontegg/types" "7.72.0"
+    "@frontegg/redux-store" "7.73.0"
+    "@frontegg/types" "7.73.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.72.0":
-  version "7.72.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.72.0.tgz#40c61d167a7e7e385cfd3667df30328c0395b5d0"
-  integrity sha512-yz8qE+0pWWTElBFCzUEZlEssI617i2qBjekaGZ8GeeB8dJBX9cqv1yS9m+pZeMlWWZ9jktIieiTgAQTVuACAIw==
+"@frontegg/redux-store@7.73.0":
+  version "7.73.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.73.0.tgz#b323e3cec53c87d7fcb3b853c34372dac0114d78"
+  integrity sha512-K5KJsjetJs3g9xdEpmbC83J4WR0dyJJiRLVnyj9Y8zWdUOK3Rb7senC5TVbIg6rPmLAIO9FBXZwLi2s4FgTwMQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.72.0"
+    "@frontegg/rest-api" "7.73.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.72.0":
-  version "7.72.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.72.0.tgz#df1a150bd9c12442dd3b50abc4f57706a39fcd6f"
-  integrity sha512-KoDO8nlgGIk9G1ruWu/pLvBQaiivKtwDxdQUSTJDLCV3KaQYuusx1P/OBslsmB5y+P2HlJk01On8jMBp2rQoIA==
+"@frontegg/rest-api@7.73.0":
+  version "7.73.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.73.0.tgz#4481a3afb23219227fe518c8518d2a8d083dc381"
+  integrity sha512-jIa8DjdDbWmLc91neJAfLchp+surFsnDooFmmoSGaPm3T5gn6kTaOvr+wRGRsnrR0HKBuZUS+MDtr9KAogz9ng==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.72.0":
-  version "7.72.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.72.0.tgz#0033b52b052075f342186ace8fb92fbc7b269266"
-  integrity sha512-jTBfgyV6fMICGjQ2n0RVWQB4l+cBJFXRbtJ2s1BC+SOaikXMBDHGxCTe1dORNTJ9keL6ieIR0ERFZNKqajPhDQ==
+"@frontegg/types@7.73.0":
+  version "7.73.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.73.0.tgz#30fd370b19f8b10218d74989ba987f1c41d30547"
+  integrity sha512-LnbCFNUWuTmHFRj1r5NysYaNVMDPg0azOEvEixRPYfqa2S/w8F4tVR3k5Q81a5efqQUNU44/UTUshyL46W763w==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.72.0"
+    "@frontegg/redux-store" "7.73.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.74.0":
-  version "7.74.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.74.0.tgz#8360c2b0611df06da288b260672db67cc0219689"
-  integrity sha512-iJQwTZLZOAOPV3KnUvSRgiFvmdZ66mzWqJ/ESLVH+Vpe0sMxgQoOpcnHEd0hALMAKznae3dV5Eso3dFhcLCp7g==
+"@frontegg/js@7.75.0":
+  version "7.75.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.75.0.tgz#cf21155057d6b38a0a1f8d18200c9aa09c2dcc2f"
+  integrity sha512-w2wsTpS3g2gA5j70Av2tsZUaSv3+ofxvDQArxE9Oq4Xm3IFUO9QkZVpY1DX1/7p1XsXexEr/3M8m0X8MvFoM2w==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.74.0"
+    "@frontegg/types" "7.75.0"
 
-"@frontegg/react-hooks@7.74.0":
-  version "7.74.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.74.0.tgz#8c4402d9aed322ed351b81aee632c00b0d63b857"
-  integrity sha512-tZTm40oPViO+D1m78AjtvwlqY5EvhDj+Ys1vrpXbvMUixHJ2SeuHrysmp20bjsXIWAbp4MBeh59BurlJnA+XsQ==
+"@frontegg/react-hooks@7.75.0":
+  version "7.75.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.75.0.tgz#cf9786c8771325f92804c9c545dd230dc1f91cc8"
+  integrity sha512-nl/AVmwSuV+EcH5M3fNmePepMsxIxBlHy3JSr0cPdqwhJin8synbPTE+w25tBVKcb9IbiqaG6ITEmqPMwm6oIA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.74.0"
-    "@frontegg/types" "7.74.0"
+    "@frontegg/redux-store" "7.75.0"
+    "@frontegg/types" "7.75.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.74.0":
-  version "7.74.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.74.0.tgz#17e9b747ba9da596a6342e8e9594ad92dd64868d"
-  integrity sha512-asQ068jvpIHNDAGsP/Y2hezk5TWcTEPKnbjZpeeZHf9h+uMRDC4rtO/FFxCUJrJBZ3P659tzLwaxUgi84MVUgQ==
+"@frontegg/redux-store@7.75.0":
+  version "7.75.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.75.0.tgz#cf76efb938862c83555dad3c5a9514dafacebbbc"
+  integrity sha512-0ohJogASOkZiB3wrrqGyEAaFaNT4p42Tu/6RShzLg6hNLs6VnIGwY6nX3/aORS1jxQ7TY5cbIhhFngCJH9ojBA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.74.0"
+    "@frontegg/rest-api" "7.75.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.74.0":
-  version "7.74.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.74.0.tgz#c4f8a5fad41bb622455fd3533278a73f583a85c5"
-  integrity sha512-se2o/ZpqH+/z8Yk25ToNXCyLZ7QHajhJAxBi5BoqdrgrWpIbG+CL20c3zDGgSazjvjv7+XNZTSRQ/SwnuGYEaA==
+"@frontegg/rest-api@7.75.0":
+  version "7.75.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.75.0.tgz#4cdd078ed93b6d56767db64acf2515d7a2e499ce"
+  integrity sha512-KPC+TNh4G168FJErsDY4qRS7CgYyvZk9X20PA/wKfmH+dV2wn08kDF8z5dCSkE+lOy88U/5IAgC/kgYDbIFxew==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.74.0":
-  version "7.74.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.74.0.tgz#8b1e449421ddc4fd6bbb41fd0908dfd34c393d26"
-  integrity sha512-WrUROQ0ItyPzZzGQ1OCz/T0HOQ9r/M8yo4ZFcIu0KAducwFaudI0QB2yEeiK255MSSmmA6qqboLgHBRQOqtFpw==
+"@frontegg/types@7.75.0":
+  version "7.75.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.75.0.tgz#bb2f07ce619e715800e7fc0e5d46f2547409897f"
+  integrity sha512-oJqwEhBw/hRzrz2OGSStcWTdFOEmkawFNyNjOlacJRvpVbApb/TMWm/HxWOj6FCCzQu57kiXf2kdpiDXZ7yZew==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.74.0"
+    "@frontegg/redux-store" "7.75.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.73.0":
-  version "7.73.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.73.0.tgz#f1466733ca2fd9a72cd393e026dac922fea70d0f"
-  integrity sha512-en4odN4xYCk+sVXbsvgcMCZPpd+iCvyQa9sur2nu08chNGEqkHoL9vqSvCpHsp9cYJyX7nWlmLCvFsAUeEkgMA==
+"@frontegg/js@7.74.0":
+  version "7.74.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.74.0.tgz#8360c2b0611df06da288b260672db67cc0219689"
+  integrity sha512-iJQwTZLZOAOPV3KnUvSRgiFvmdZ66mzWqJ/ESLVH+Vpe0sMxgQoOpcnHEd0hALMAKznae3dV5Eso3dFhcLCp7g==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.73.0"
+    "@frontegg/types" "7.74.0"
 
-"@frontegg/react-hooks@7.73.0":
-  version "7.73.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.73.0.tgz#90c0b484793e696976cc5da1bcbe859e3755cc11"
-  integrity sha512-yvYE1PGgWKMlKPO7bsK0DCVJmGwzjLz+l5NnolKrtbWcAKcqV6qgkp73igljkOd8tYWtyiotqP36Y/5G/tyWrA==
+"@frontegg/react-hooks@7.74.0":
+  version "7.74.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.74.0.tgz#8c4402d9aed322ed351b81aee632c00b0d63b857"
+  integrity sha512-tZTm40oPViO+D1m78AjtvwlqY5EvhDj+Ys1vrpXbvMUixHJ2SeuHrysmp20bjsXIWAbp4MBeh59BurlJnA+XsQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.73.0"
-    "@frontegg/types" "7.73.0"
+    "@frontegg/redux-store" "7.74.0"
+    "@frontegg/types" "7.74.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.73.0":
-  version "7.73.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.73.0.tgz#b323e3cec53c87d7fcb3b853c34372dac0114d78"
-  integrity sha512-K5KJsjetJs3g9xdEpmbC83J4WR0dyJJiRLVnyj9Y8zWdUOK3Rb7senC5TVbIg6rPmLAIO9FBXZwLi2s4FgTwMQ==
+"@frontegg/redux-store@7.74.0":
+  version "7.74.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.74.0.tgz#17e9b747ba9da596a6342e8e9594ad92dd64868d"
+  integrity sha512-asQ068jvpIHNDAGsP/Y2hezk5TWcTEPKnbjZpeeZHf9h+uMRDC4rtO/FFxCUJrJBZ3P659tzLwaxUgi84MVUgQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.73.0"
+    "@frontegg/rest-api" "7.74.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.73.0":
-  version "7.73.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.73.0.tgz#4481a3afb23219227fe518c8518d2a8d083dc381"
-  integrity sha512-jIa8DjdDbWmLc91neJAfLchp+surFsnDooFmmoSGaPm3T5gn6kTaOvr+wRGRsnrR0HKBuZUS+MDtr9KAogz9ng==
+"@frontegg/rest-api@7.74.0":
+  version "7.74.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.74.0.tgz#c4f8a5fad41bb622455fd3533278a73f583a85c5"
+  integrity sha512-se2o/ZpqH+/z8Yk25ToNXCyLZ7QHajhJAxBi5BoqdrgrWpIbG+CL20c3zDGgSazjvjv7+XNZTSRQ/SwnuGYEaA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.73.0":
-  version "7.73.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.73.0.tgz#30fd370b19f8b10218d74989ba987f1c41d30547"
-  integrity sha512-LnbCFNUWuTmHFRj1r5NysYaNVMDPg0azOEvEixRPYfqa2S/w8F4tVR3k5Q81a5efqQUNU44/UTUshyL46W763w==
+"@frontegg/types@7.74.0":
+  version "7.74.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.74.0.tgz#8b1e449421ddc4fd6bbb41fd0908dfd34c393d26"
+  integrity sha512-WrUROQ0ItyPzZzGQ1OCz/T0HOQ9r/M8yo4ZFcIu0KAducwFaudI0QB2yEeiK255MSSmmA6qqboLgHBRQOqtFpw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.73.0"
+    "@frontegg/redux-store" "7.74.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.71.0":
-  version "7.71.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.71.0.tgz#7b088c4ff9a8d16074f4e3cb46febdf166c7149c"
-  integrity sha512-cedBv2Ag9BmkXjEsDiVLhjFQ5XpSmofPMqsT7/Yxp8y3MsNdSfQaj/OaF0Y258f3XUsg5A51oyO4TJ6yiZz3mg==
+"@frontegg/js@7.72.0":
+  version "7.72.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.72.0.tgz#8da75af948b45df89a13974c87e028a8372c0b4a"
+  integrity sha512-GQ0TJ4Qly6MUmBuF0fm6ZZz4pebXbVlX0sqZFJMPqDjmGn29HuYUF1y9N8LEC8NACeUgl9ctvPse0ObMe6y/IA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.71.0"
+    "@frontegg/types" "7.72.0"
 
-"@frontegg/react-hooks@7.71.0":
-  version "7.71.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.71.0.tgz#252fccf9fdbbfd66e597025742f61e2afb25069f"
-  integrity sha512-9IJIf96zb8uoNdELjBh0A4NgNm2gyyrZyLCccYTpLQ+n1WQ7zgeW6EStxGLFzTL8Gu4kvpEi1jltCzhRyoautg==
+"@frontegg/react-hooks@7.72.0":
+  version "7.72.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.72.0.tgz#e735fb5a7e3fffdfbc4afe278e4da4244c2e3c92"
+  integrity sha512-GEwdENAghmrre7ZyASVPt5vuTMIJ5y2lUK+oylx4eJdkBNyjVvS3xEtQdBg0BuwszNzxrbN34c1olZZE8j5xTw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.71.0"
-    "@frontegg/types" "7.71.0"
+    "@frontegg/redux-store" "7.72.0"
+    "@frontegg/types" "7.72.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.71.0":
-  version "7.71.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.71.0.tgz#b44a112518883363c9362ff35c511ecbbef442c3"
-  integrity sha512-meGeqcpmanw7LD5vLmj4Zau3Qp7yLeZZkBOWK+mOCT9sz90xCXcunik0rq5E3qLdxYU1d4k9Amzi7y0uHXApxw==
+"@frontegg/redux-store@7.72.0":
+  version "7.72.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.72.0.tgz#40c61d167a7e7e385cfd3667df30328c0395b5d0"
+  integrity sha512-yz8qE+0pWWTElBFCzUEZlEssI617i2qBjekaGZ8GeeB8dJBX9cqv1yS9m+pZeMlWWZ9jktIieiTgAQTVuACAIw==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.71.0"
+    "@frontegg/rest-api" "7.72.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.71.0":
-  version "7.71.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.71.0.tgz#dd6fb91e72a29b150820e4e90852c36a52939415"
-  integrity sha512-TY58V+Z873DUdsW33URHJFo+fSRd/xYvUa1+oa5rSrD4TTc8WrnXWwGKIXAFDX6Ct3YrMD9ADpF1RQ11L2ygzA==
+"@frontegg/rest-api@7.72.0":
+  version "7.72.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.72.0.tgz#df1a150bd9c12442dd3b50abc4f57706a39fcd6f"
+  integrity sha512-KoDO8nlgGIk9G1ruWu/pLvBQaiivKtwDxdQUSTJDLCV3KaQYuusx1P/OBslsmB5y+P2HlJk01On8jMBp2rQoIA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.71.0":
-  version "7.71.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.71.0.tgz#bd052262e6cad6e3edb76d61ece6c7d699dc2488"
-  integrity sha512-o1urCEWAZElSZZxbOAGfZklhGg/8vknRkg8BuOPGzYlMudya09G+Q75LqycHbwouH8isMHOJ+NbUD7TvsZkFIg==
+"@frontegg/types@7.72.0":
+  version "7.72.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.72.0.tgz#0033b52b052075f342186ace8fb92fbc7b269266"
+  integrity sha512-jTBfgyV6fMICGjQ2n0RVWQB4l+cBJFXRbtJ2s1BC+SOaikXMBDHGxCTe1dORNTJ9keL6ieIR0ERFZNKqajPhDQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.71.0"
+    "@frontegg/redux-store" "7.72.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-21024 - Added callback to reset password cmc
- FR-20953 - Added Display specific countries for phone number
- FR-20733 - Fixed Screen flickering after forget password success
- FR-20104 - Fixed Issue with search term persistence in the Personal and non-Personal API Tokens modals
- FR-20811 - Fixed optional localizations deep partial type
- FR-20407 - Added localization support for 25 languages


- FR-20899 - Changed logout user session button
- FR-20901 - Fixed select actions menu item
- FR-20871 - Added support for default language
- FR-20894 - Added support regex in string input


- FR-19718 - Added username strategies


- FR-20337 - Fixed errors not displayed on submit


- FR-19738 - Fixed invite dialog CMC

- FR-19738 - Added support for CMC components
