### PR TITLE
Update Frontegg AdminPortal to 7.122.0

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.96.0",
-    "@frontegg/react-hooks": "7.96.0",
+    "@frontegg/js": "7.97.0",
+    "@frontegg/react-hooks": "7.97.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.95.0",
-    "@frontegg/react-hooks": "7.95.0",
+    "@frontegg/js": "7.96.0",
+    "@frontegg/react-hooks": "7.96.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.97.0",
-    "@frontegg/react-hooks": "7.97.0",
+    "@frontegg/js": "7.99.0",
+    "@frontegg/react-hooks": "7.99.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.100.0",
-    "@frontegg/react-hooks": "7.100.0",
+    "@frontegg/js": "7.101.0",
+    "@frontegg/react-hooks": "7.101.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.101.0",
-    "@frontegg/react-hooks": "7.101.0",
+    "@frontegg/js": "7.102.0",
+    "@frontegg/react-hooks": "7.102.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.99.0",
-    "@frontegg/react-hooks": "7.99.0",
+    "@frontegg/js": "7.100.0",
+    "@frontegg/react-hooks": "7.100.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.118.0",
-    "@frontegg/react-hooks": "7.118.0",
+    "@frontegg/js": "7.119.0",
+    "@frontegg/react-hooks": "7.119.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.112.0",
-    "@frontegg/react-hooks": "7.112.0",
+    "@frontegg/js": "7.113.0",
+    "@frontegg/react-hooks": "7.113.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.107.0",
-    "@frontegg/react-hooks": "7.107.0",
+    "@frontegg/js": "7.108.0",
+    "@frontegg/react-hooks": "7.108.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.114.0",
-    "@frontegg/react-hooks": "7.114.0",
+    "@frontegg/js": "7.115.0",
+    "@frontegg/react-hooks": "7.115.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.105.0",
-    "@frontegg/react-hooks": "7.105.0",
+    "@frontegg/js": "7.106.0",
+    "@frontegg/react-hooks": "7.106.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.109.0",
-    "@frontegg/react-hooks": "7.109.0",
+    "@frontegg/js": "7.110.0",
+    "@frontegg/react-hooks": "7.110.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.106.0",
-    "@frontegg/react-hooks": "7.106.0",
+    "@frontegg/js": "7.107.0",
+    "@frontegg/react-hooks": "7.107.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.108.0",
-    "@frontegg/react-hooks": "7.108.0",
+    "@frontegg/js": "7.109.0",
+    "@frontegg/react-hooks": "7.109.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.115.0",
-    "@frontegg/react-hooks": "7.115.0",
+    "@frontegg/js": "7.116.0",
+    "@frontegg/react-hooks": "7.116.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.104.0",
-    "@frontegg/react-hooks": "7.104.0",
+    "@frontegg/js": "7.105.0",
+    "@frontegg/react-hooks": "7.105.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.116.0",
-    "@frontegg/react-hooks": "7.116.0",
+    "@frontegg/js": "7.117.0",
+    "@frontegg/react-hooks": "7.117.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.113.0",
-    "@frontegg/react-hooks": "7.113.0",
+    "@frontegg/js": "7.114.0",
+    "@frontegg/react-hooks": "7.114.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.102.0",
-    "@frontegg/react-hooks": "7.102.0",
+    "@frontegg/js": "7.103.0",
+    "@frontegg/react-hooks": "7.103.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.103.0",
-    "@frontegg/react-hooks": "7.103.0",
+    "@frontegg/js": "7.104.0",
+    "@frontegg/react-hooks": "7.104.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.111.0",
-    "@frontegg/react-hooks": "7.111.0",
+    "@frontegg/js": "7.112.0",
+    "@frontegg/react-hooks": "7.112.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.117.0",
-    "@frontegg/react-hooks": "7.117.0",
+    "@frontegg/js": "7.118.0",
+    "@frontegg/react-hooks": "7.118.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.110.0",
-    "@frontegg/react-hooks": "7.110.0",
+    "@frontegg/js": "7.111.0",
+    "@frontegg/react-hooks": "7.111.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.120.0",
-    "@frontegg/react-hooks": "7.120.0",
+    "@frontegg/js": "7.121.0",
+    "@frontegg/react-hooks": "7.121.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.119.0",
-    "@frontegg/react-hooks": "7.119.0",
+    "@frontegg/js": "7.120.0",
+    "@frontegg/react-hooks": "7.120.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,8 +27,8 @@
     "lint-json": "eslint -c .eslintrc.json -o ./lint-report.json --format json --no-color ./src/**/*.{ts,tsx}"
   },
   "dependencies": {
-    "@frontegg/js": "7.121.0",
-    "@frontegg/react-hooks": "7.121.0",
+    "@frontegg/js": "7.122.0",
+    "@frontegg/react-hooks": "7.122.0",
     "http-proxy": "^1.18.1",
     "iron-session": "^6.3.1",
     "jose": "^4.12.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.95.0":
-  version "7.95.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.95.0.tgz#674f255df59d69e90fd65601993c1bbf7d8a5b82"
-  integrity sha512-j2zDJwJLqErN85UqVXyShW+8NqcgUNKSR+IKL0QhoNfUBtuT8D6MohWXDW6z9P8gQ4CqzXHIH1tSNRjGLE63hQ==
+"@frontegg/js@7.96.0":
+  version "7.96.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.96.0.tgz#51d41cd9a40e4b685da577b6378276d759f93202"
+  integrity sha512-XUWj607h8W4gHoSwNNl6z2I1OY2lzjbpFBCSAavNk9zCBS6FMEHm7VLSfhhT2NJ2ha6xbvyatXe9/tvOVjKmJg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.95.0"
+    "@frontegg/types" "7.96.0"
 
-"@frontegg/react-hooks@7.95.0":
-  version "7.95.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.95.0.tgz#89221c6c12aafa02819fb15d094099e2ad3d9b59"
-  integrity sha512-vPwBLSDfqon5NlAKWpRaRiSOAFBrzvteVUrm0+l5kEJpjdwzDzRQ4Y0N0vS1VvqayGZujghwwh3zm7wqtNlz0g==
+"@frontegg/react-hooks@7.96.0":
+  version "7.96.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.96.0.tgz#a8de180f9afc8a295e7055d7b549d5aae4ed6f97"
+  integrity sha512-4Yuog4C5qqnjpX657gk8hlxiRkcl3HpqPJu80sDlwxFcXdCCZbR3yT35+kuNFXkB8cok/m2DuqalQrFzOdw0bA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.95.0"
-    "@frontegg/types" "7.95.0"
+    "@frontegg/redux-store" "7.96.0"
+    "@frontegg/types" "7.96.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.95.0":
-  version "7.95.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.95.0.tgz#91b7fd8a4f90bded82b6a06d465a85e55465aaea"
-  integrity sha512-DSjWTH0FjkyyA3KzzQ8uch3PqnFzBLIsvAQQ5LG/GMOMxMxv5TtIaDAtWdXAA+keUVL8GFaxqe8QoGNlhK7cHQ==
+"@frontegg/redux-store@7.96.0":
+  version "7.96.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.96.0.tgz#43a3dbe8673aaa194166e7128f61cc0109691d24"
+  integrity sha512-xCtkGoyGiXCH32V/zIjfX+QDm9t5AqrUo4xMgnbucongG1X4a3gvi3Xlky2YtziBhykhJIb+3RiEyGiD5xvmVQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.95.0"
+    "@frontegg/rest-api" "7.96.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.95.0":
-  version "7.95.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.95.0.tgz#6987e460faf5c9566c6dfdd0a7e17d4610949115"
-  integrity sha512-ApNgLznvp/NCbp0E3yeqpEymNSTP6pSXowEwSyRWeg8XK29yUNCDTyVn/3iq8WztcXiH+Os/y32q2pCsdb0i5Q==
+"@frontegg/rest-api@7.96.0":
+  version "7.96.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.96.0.tgz#5ff809ddeaa85179f411b38d7ca9572321a1b6d7"
+  integrity sha512-17FEWl2hglyIAXC5BUSJoS7v7dzKw/1bSuJhCd5QEZ8+d75CGNrBLeDoqTpDxQLED1K3QTEPFm4kgGrwh9BB/Q==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.95.0":
-  version "7.95.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.95.0.tgz#b4adfb413a2b6c0f2088f9655fa4af6a67be96b0"
-  integrity sha512-Uqs4kEzvdH7iU4P9bPuNCO7nX2d5xvlbxCJyZWXbxKLGvcnbWdTjFa+u82/rXi1cdS5XgUWwUcqkIIu9uNJzSw==
+"@frontegg/types@7.96.0":
+  version "7.96.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.96.0.tgz#d29d61f81fb23e28dea4e83723e3a6abe80cf901"
+  integrity sha512-8EfXgxzVybd4cK+s7BvOQe99aVWcAYiEujgPAfgx+yIB3k9+FjZuez7kGJ4wV433fOXwdBLqq+vUYn1u167ltg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.95.0"
+    "@frontegg/redux-store" "7.96.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.96.0":
-  version "7.96.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.96.0.tgz#51d41cd9a40e4b685da577b6378276d759f93202"
-  integrity sha512-XUWj607h8W4gHoSwNNl6z2I1OY2lzjbpFBCSAavNk9zCBS6FMEHm7VLSfhhT2NJ2ha6xbvyatXe9/tvOVjKmJg==
+"@frontegg/js@7.97.0":
+  version "7.97.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.97.0.tgz#eaabbc8af57ace4bf10ea0e02c327413c6180095"
+  integrity sha512-66bWUQOSzjA1YdRggVMZRETq1zIjn8IkEq2auymbcvy03J/OPYnuDF1QUv6slD8Q0beEhhsJa04xiICgRWF11Q==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.96.0"
+    "@frontegg/types" "7.97.0"
 
-"@frontegg/react-hooks@7.96.0":
-  version "7.96.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.96.0.tgz#a8de180f9afc8a295e7055d7b549d5aae4ed6f97"
-  integrity sha512-4Yuog4C5qqnjpX657gk8hlxiRkcl3HpqPJu80sDlwxFcXdCCZbR3yT35+kuNFXkB8cok/m2DuqalQrFzOdw0bA==
+"@frontegg/react-hooks@7.97.0":
+  version "7.97.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.97.0.tgz#13a0f8fab7e61d97246ec9b077e23feddd6fa34b"
+  integrity sha512-J+zHweHGdnVANnTYixVg/TggGzgg8KYEnuG0MCVGl14Nkdw85xG78OMmbnePEHNY1NBE266/m7HpK7rYIPpimQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.96.0"
-    "@frontegg/types" "7.96.0"
+    "@frontegg/redux-store" "7.97.0"
+    "@frontegg/types" "7.97.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.96.0":
-  version "7.96.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.96.0.tgz#43a3dbe8673aaa194166e7128f61cc0109691d24"
-  integrity sha512-xCtkGoyGiXCH32V/zIjfX+QDm9t5AqrUo4xMgnbucongG1X4a3gvi3Xlky2YtziBhykhJIb+3RiEyGiD5xvmVQ==
+"@frontegg/redux-store@7.97.0":
+  version "7.97.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.97.0.tgz#28f145053c30104232d351e0d81fa3a6861281c8"
+  integrity sha512-qHABnoQ54rAjKKTWQmIC6ZbsWbVHpH28zKYzhy2HEjucG8P56F8dAVEyGrN1dW4hMQBJOwL9xmCvw9GxczoN4A==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.96.0"
+    "@frontegg/rest-api" "7.97.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.96.0":
-  version "7.96.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.96.0.tgz#5ff809ddeaa85179f411b38d7ca9572321a1b6d7"
-  integrity sha512-17FEWl2hglyIAXC5BUSJoS7v7dzKw/1bSuJhCd5QEZ8+d75CGNrBLeDoqTpDxQLED1K3QTEPFm4kgGrwh9BB/Q==
+"@frontegg/rest-api@7.97.0":
+  version "7.97.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.97.0.tgz#aedcd1f9afca6c090c499f372a6494933730b6a5"
+  integrity sha512-YvFwFQ09D/DnlLq16dj6bqrbN2tzrf2brweL6Yv7PDmDZ8yGBIMuPYUQSWQ7WYbfu+BBqCdins5XTnuANywCtg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.96.0":
-  version "7.96.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.96.0.tgz#d29d61f81fb23e28dea4e83723e3a6abe80cf901"
-  integrity sha512-8EfXgxzVybd4cK+s7BvOQe99aVWcAYiEujgPAfgx+yIB3k9+FjZuez7kGJ4wV433fOXwdBLqq+vUYn1u167ltg==
+"@frontegg/types@7.97.0":
+  version "7.97.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.97.0.tgz#9f0c9ab32bdc9e58a0c1b06c2f0bfbc7b4d6db01"
+  integrity sha512-avAlM/rmOKeYVZET5CmwEmFck6oggKDdeWhOy0DgZml4a+CT9Y77UZArUM3jcACfxoEZwXxJI15we/oQYgdnNQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.96.0"
+    "@frontegg/redux-store" "7.97.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.100.0":
-  version "7.100.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.100.0.tgz#467d2ebca9a1412cb354077fd5f6e58873b06f71"
-  integrity sha512-cjpGk9/E+3isN6YY2stHbwh/4TUfA8gFYwtC3R8wv4lKmDGkPq+PRHb7CHSJLuRd0O496nsWdbvgNp8u44mPag==
+"@frontegg/js@7.101.0":
+  version "7.101.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.101.0.tgz#9481ad8b24b808de6675657bdbb25e96087a2e7c"
+  integrity sha512-wkLmwhhtLNqaXA0IaJ4/beE+1wWZgdoj0NuDqA0wHKh2LRRs/0C9SWoPS4OcMJW3sGT+hxN+OquA3Snr69bpxw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.100.0"
+    "@frontegg/types" "7.101.0"
 
-"@frontegg/react-hooks@7.100.0":
-  version "7.100.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.100.0.tgz#0b49408eaa4309a44557fccc271f47f8893d0253"
-  integrity sha512-VbZGoM5eqo2+EhUc9Oos4O2GTD4qVB8qgR21BQvtlhYOzbud6LOK566OtmZ+OIQKM/TqU0jMzxhqDL5yJp1LAg==
+"@frontegg/react-hooks@7.101.0":
+  version "7.101.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.101.0.tgz#cab4d0bb08e44ac6e525671283550727d7616e27"
+  integrity sha512-uiU+KBEXj24+exbT3n+h4ELIJY35cDQvqeKHwejjgSn7Zk7tz0EEr0mB2a1NSpi7U8/fto+hVgj3kMMRskHQhw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.100.0"
-    "@frontegg/types" "7.100.0"
+    "@frontegg/redux-store" "7.101.0"
+    "@frontegg/types" "7.101.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.100.0":
-  version "7.100.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.100.0.tgz#62553a6432e716a9810dd9fb256968698c83acc3"
-  integrity sha512-BMKaT41I8yWDrccujO9ka8Va+EzUHVmqZBbV8UsxPOzaSW+PtiMTIxoZrmuymufGo2PG68H0NrVO1XWFsetZfA==
+"@frontegg/redux-store@7.101.0":
+  version "7.101.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.101.0.tgz#e89d1f70c15ac5d26c5059fa3cb0d7848959bae4"
+  integrity sha512-AiqwUXl4oCV5KkDRornIwbGvviaFtmdmF9fAoBwtc+VKR1Iw9yZJSU59llubv5rTZmJR6L/98eDtqv0f/CawpA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.100.0"
+    "@frontegg/rest-api" "7.101.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.100.0":
-  version "7.100.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.100.0.tgz#f094587b0ded1001000138ed139fd18a8db7c220"
-  integrity sha512-ohWUT+rRtWPtJsSuX6pbsSGYgf3BJ4Ay4+3Q5VgYN5oske7Bx7SZoI9RQjpr14FEY5gEQ6PY4seDKaG0aQOcWA==
+"@frontegg/rest-api@7.101.0":
+  version "7.101.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.101.0.tgz#d0ffb550d08d0bab7b15aef1a0b637b787604619"
+  integrity sha512-zWWYFzf7cjw6xeeBKDqOyacgB9YDa6t/mpzh+pc/bb4aHz2e8rMzJAxhZkwJZUI/yU/dMsTe1loIEC84JgE5pw==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.100.0":
-  version "7.100.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.100.0.tgz#1e70f6b51298f4c5263501f5795b28496bc348a0"
-  integrity sha512-9NWYMdFoGERc8j483GHp8gX8bgQ9eFQtM8v+OkeGpinOZ7tdNU/zf8C7armD8hM18WekL8vLJBjmKm8oS9JMwA==
+"@frontegg/types@7.101.0":
+  version "7.101.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.101.0.tgz#254c9a3cb468a393066b5facfb7627922b318199"
+  integrity sha512-B1T1f50xvg4EUGRZtQPDBk3PpgZSdxGj5Fx3ltvVcD5Wxj1z+OTO3YFEM88dxM2PkNSMQzDneekruaVeEr+paA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.100.0"
+    "@frontegg/redux-store" "7.101.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.97.0":
-  version "7.97.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.97.0.tgz#eaabbc8af57ace4bf10ea0e02c327413c6180095"
-  integrity sha512-66bWUQOSzjA1YdRggVMZRETq1zIjn8IkEq2auymbcvy03J/OPYnuDF1QUv6slD8Q0beEhhsJa04xiICgRWF11Q==
+"@frontegg/js@7.99.0":
+  version "7.99.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.99.0.tgz#686bc75ee1ed54f2e6ffe8e93c8c142664bf5a6f"
+  integrity sha512-LgbfKJo37k41B5flLFX3hkIm60wWBmHWoW78Z/eTlfl0SddnHxKh7zJ0GkAcMt+2MfGxsqZCXy2IpOzMNXnt6A==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.97.0"
+    "@frontegg/types" "7.99.0"
 
-"@frontegg/react-hooks@7.97.0":
-  version "7.97.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.97.0.tgz#13a0f8fab7e61d97246ec9b077e23feddd6fa34b"
-  integrity sha512-J+zHweHGdnVANnTYixVg/TggGzgg8KYEnuG0MCVGl14Nkdw85xG78OMmbnePEHNY1NBE266/m7HpK7rYIPpimQ==
+"@frontegg/react-hooks@7.99.0":
+  version "7.99.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.99.0.tgz#5a3997be8b30729f9d1048d0e647c32101a2c2d0"
+  integrity sha512-NXRJT+dLe05VSNw2bscGLlxB9o7SE5UWA+HQQgBqxzWoecTqiW5i5s2m6QUI3OwY/dAYGPJMrDTIL+2SZaw66Q==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.97.0"
-    "@frontegg/types" "7.97.0"
+    "@frontegg/redux-store" "7.99.0"
+    "@frontegg/types" "7.99.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.97.0":
-  version "7.97.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.97.0.tgz#28f145053c30104232d351e0d81fa3a6861281c8"
-  integrity sha512-qHABnoQ54rAjKKTWQmIC6ZbsWbVHpH28zKYzhy2HEjucG8P56F8dAVEyGrN1dW4hMQBJOwL9xmCvw9GxczoN4A==
+"@frontegg/redux-store@7.99.0":
+  version "7.99.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.99.0.tgz#fedb571081938497dd3e2d5bf600d9728e49c13d"
+  integrity sha512-01rXqfo364I6q1wip/EoPybs+DU1OIy5rgdKDcOQ25oC4Br+v0GUVyCTnEsvtSGOQZPLaH515EyIe1r7eupXKQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.97.0"
+    "@frontegg/rest-api" "7.99.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.97.0":
-  version "7.97.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.97.0.tgz#aedcd1f9afca6c090c499f372a6494933730b6a5"
-  integrity sha512-YvFwFQ09D/DnlLq16dj6bqrbN2tzrf2brweL6Yv7PDmDZ8yGBIMuPYUQSWQ7WYbfu+BBqCdins5XTnuANywCtg==
+"@frontegg/rest-api@7.99.0":
+  version "7.99.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.99.0.tgz#8c25c265e01ac4643c8b5831b9d0434a33b2826c"
+  integrity sha512-AEaBppndfjPNuAOJcC5QO83Q7CM5ywxCGAcpvjrOoU9fVmXI5SSdzqdIAMFXrjggXN+l937pCeCdfkXhckG37w==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.97.0":
-  version "7.97.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.97.0.tgz#9f0c9ab32bdc9e58a0c1b06c2f0bfbc7b4d6db01"
-  integrity sha512-avAlM/rmOKeYVZET5CmwEmFck6oggKDdeWhOy0DgZml4a+CT9Y77UZArUM3jcACfxoEZwXxJI15we/oQYgdnNQ==
+"@frontegg/types@7.99.0":
+  version "7.99.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.99.0.tgz#d0d2f90bb61eedaa4b38e9682a21de2b4a7217bd"
+  integrity sha512-bWPr8cnRJyhQ3EFDswrqEBs5z7EaRhvB7bepbjIycIP/84Jqef3IfPO8/fAPLJRnA2v0TqnlCmRMcXnLT6pi4Q==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.97.0"
+    "@frontegg/redux-store" "7.99.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.99.0":
-  version "7.99.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.99.0.tgz#686bc75ee1ed54f2e6ffe8e93c8c142664bf5a6f"
-  integrity sha512-LgbfKJo37k41B5flLFX3hkIm60wWBmHWoW78Z/eTlfl0SddnHxKh7zJ0GkAcMt+2MfGxsqZCXy2IpOzMNXnt6A==
+"@frontegg/js@7.100.0":
+  version "7.100.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.100.0.tgz#467d2ebca9a1412cb354077fd5f6e58873b06f71"
+  integrity sha512-cjpGk9/E+3isN6YY2stHbwh/4TUfA8gFYwtC3R8wv4lKmDGkPq+PRHb7CHSJLuRd0O496nsWdbvgNp8u44mPag==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.99.0"
+    "@frontegg/types" "7.100.0"
 
-"@frontegg/react-hooks@7.99.0":
-  version "7.99.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.99.0.tgz#5a3997be8b30729f9d1048d0e647c32101a2c2d0"
-  integrity sha512-NXRJT+dLe05VSNw2bscGLlxB9o7SE5UWA+HQQgBqxzWoecTqiW5i5s2m6QUI3OwY/dAYGPJMrDTIL+2SZaw66Q==
+"@frontegg/react-hooks@7.100.0":
+  version "7.100.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.100.0.tgz#0b49408eaa4309a44557fccc271f47f8893d0253"
+  integrity sha512-VbZGoM5eqo2+EhUc9Oos4O2GTD4qVB8qgR21BQvtlhYOzbud6LOK566OtmZ+OIQKM/TqU0jMzxhqDL5yJp1LAg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.99.0"
-    "@frontegg/types" "7.99.0"
+    "@frontegg/redux-store" "7.100.0"
+    "@frontegg/types" "7.100.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.99.0":
-  version "7.99.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.99.0.tgz#fedb571081938497dd3e2d5bf600d9728e49c13d"
-  integrity sha512-01rXqfo364I6q1wip/EoPybs+DU1OIy5rgdKDcOQ25oC4Br+v0GUVyCTnEsvtSGOQZPLaH515EyIe1r7eupXKQ==
+"@frontegg/redux-store@7.100.0":
+  version "7.100.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.100.0.tgz#62553a6432e716a9810dd9fb256968698c83acc3"
+  integrity sha512-BMKaT41I8yWDrccujO9ka8Va+EzUHVmqZBbV8UsxPOzaSW+PtiMTIxoZrmuymufGo2PG68H0NrVO1XWFsetZfA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.99.0"
+    "@frontegg/rest-api" "7.100.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.99.0":
-  version "7.99.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.99.0.tgz#8c25c265e01ac4643c8b5831b9d0434a33b2826c"
-  integrity sha512-AEaBppndfjPNuAOJcC5QO83Q7CM5ywxCGAcpvjrOoU9fVmXI5SSdzqdIAMFXrjggXN+l937pCeCdfkXhckG37w==
+"@frontegg/rest-api@7.100.0":
+  version "7.100.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.100.0.tgz#f094587b0ded1001000138ed139fd18a8db7c220"
+  integrity sha512-ohWUT+rRtWPtJsSuX6pbsSGYgf3BJ4Ay4+3Q5VgYN5oske7Bx7SZoI9RQjpr14FEY5gEQ6PY4seDKaG0aQOcWA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.99.0":
-  version "7.99.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.99.0.tgz#d0d2f90bb61eedaa4b38e9682a21de2b4a7217bd"
-  integrity sha512-bWPr8cnRJyhQ3EFDswrqEBs5z7EaRhvB7bepbjIycIP/84Jqef3IfPO8/fAPLJRnA2v0TqnlCmRMcXnLT6pi4Q==
+"@frontegg/types@7.100.0":
+  version "7.100.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.100.0.tgz#1e70f6b51298f4c5263501f5795b28496bc348a0"
+  integrity sha512-9NWYMdFoGERc8j483GHp8gX8bgQ9eFQtM8v+OkeGpinOZ7tdNU/zf8C7armD8hM18WekL8vLJBjmKm8oS9JMwA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.99.0"
+    "@frontegg/redux-store" "7.100.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.101.0":
-  version "7.101.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.101.0.tgz#9481ad8b24b808de6675657bdbb25e96087a2e7c"
-  integrity sha512-wkLmwhhtLNqaXA0IaJ4/beE+1wWZgdoj0NuDqA0wHKh2LRRs/0C9SWoPS4OcMJW3sGT+hxN+OquA3Snr69bpxw==
+"@frontegg/js@7.102.0":
+  version "7.102.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.102.0.tgz#df984daba79ea485115567e55fb304e244a39cc4"
+  integrity sha512-zuOBw5g0YydUYJZpRCM3rr4W0m8HwyuqL04Bs7GuTA6aKqFZIEus5/F1uOhyLgR13ibWWH77UelLjp4IfKyzUQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.101.0"
+    "@frontegg/types" "7.102.0"
 
-"@frontegg/react-hooks@7.101.0":
-  version "7.101.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.101.0.tgz#cab4d0bb08e44ac6e525671283550727d7616e27"
-  integrity sha512-uiU+KBEXj24+exbT3n+h4ELIJY35cDQvqeKHwejjgSn7Zk7tz0EEr0mB2a1NSpi7U8/fto+hVgj3kMMRskHQhw==
+"@frontegg/react-hooks@7.102.0":
+  version "7.102.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.102.0.tgz#9c014675b0b2b54af8f8d6d30ca8922db896b401"
+  integrity sha512-Ff7ZDsdhLLmE1HWOz6GRzZhJ/xVYFkpNlGTMWiE1d9E4HcCC5gvqd2NKy4hsOuQn/r4eaMB10j1StfxW8WYvJg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.101.0"
-    "@frontegg/types" "7.101.0"
+    "@frontegg/redux-store" "7.102.0"
+    "@frontegg/types" "7.102.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.101.0":
-  version "7.101.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.101.0.tgz#e89d1f70c15ac5d26c5059fa3cb0d7848959bae4"
-  integrity sha512-AiqwUXl4oCV5KkDRornIwbGvviaFtmdmF9fAoBwtc+VKR1Iw9yZJSU59llubv5rTZmJR6L/98eDtqv0f/CawpA==
+"@frontegg/redux-store@7.102.0":
+  version "7.102.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.102.0.tgz#013192952564d8fd28cfde2cffd5af323b538148"
+  integrity sha512-CdvtKo+JcdeZvJ6/34PCUMtz95Sh30mypcomiU3uYnjJ3PTv3XVfAj/wmhIAQh1MC1FoV5mx6GOs5/SzoXoDpg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.101.0"
+    "@frontegg/rest-api" "7.102.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.101.0":
-  version "7.101.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.101.0.tgz#d0ffb550d08d0bab7b15aef1a0b637b787604619"
-  integrity sha512-zWWYFzf7cjw6xeeBKDqOyacgB9YDa6t/mpzh+pc/bb4aHz2e8rMzJAxhZkwJZUI/yU/dMsTe1loIEC84JgE5pw==
+"@frontegg/rest-api@7.102.0":
+  version "7.102.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.102.0.tgz#3c4883ce513a6b0825ff6cf420818821f4cc854b"
+  integrity sha512-mLUzzskjhYZ6bZgy6x2PxnoLgGIu2wa8VbpJufGnWtIgIPrkdub6/OGQVaSsPyRzhdL3/vbSgAPpK5GL8dMqWQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.101.0":
-  version "7.101.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.101.0.tgz#254c9a3cb468a393066b5facfb7627922b318199"
-  integrity sha512-B1T1f50xvg4EUGRZtQPDBk3PpgZSdxGj5Fx3ltvVcD5Wxj1z+OTO3YFEM88dxM2PkNSMQzDneekruaVeEr+paA==
+"@frontegg/types@7.102.0":
+  version "7.102.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.102.0.tgz#9269d634cf0de5194cef9ff99b98f153117e2cdf"
+  integrity sha512-KUI/iP3v3um+AY3apBEFklv9uc2x0XNMnyR9bQkvcwGW0Ia+jcUH508gskXYj5W2UxU9QGiXG2tnRFTq8ytHKQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.101.0"
+    "@frontegg/redux-store" "7.102.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.111.0":
-  version "7.111.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.111.0.tgz#ab06b82501a072751e0fd964c39d423fab8558c1"
-  integrity sha512-pDNJLykhVNwO9smFbWTjNKOtO2XOhLrTwYelC0Hah0cC/BNtZyogV8SoGOy5CP0ni1DFGBGJjjZNxRaZT8YwQw==
+"@frontegg/js@7.112.0":
+  version "7.112.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.112.0.tgz#183503ebbd89b334a37dcf65749d59941ef30120"
+  integrity sha512-RSKi5vg8fBePLl1bD7MrsKIt4QVHpUKl1p98Bf2lh9vZtCwK6ZNucnF/oeLio0HGUUY8ciCZJEJgX/RW7quwCw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.111.0"
+    "@frontegg/types" "7.112.0"
 
-"@frontegg/react-hooks@7.111.0":
-  version "7.111.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.111.0.tgz#d37c0badede0d726cb1d6f15d3882ca0f7b45bed"
-  integrity sha512-F4cbPGhqpH5KeFNMXuf9D1ChW/fSLPFEdIBv4Eu30GwVlI82MFb3yFHPMMXcK4QXYB5bn98VEGW4fuusKv8VKQ==
+"@frontegg/react-hooks@7.112.0":
+  version "7.112.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.112.0.tgz#f0be20c6f9c281952dc0bb8c08405ec057b2a781"
+  integrity sha512-Pu0NMByLBv4+bY0IwR9QFd6q87OW8moFo6VbHRWzzM1ISM3XUyxCj9nd8nvq7ffwMpKO/uyZL0rQYFXsKp/Fxg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.111.0"
-    "@frontegg/types" "7.111.0"
+    "@frontegg/redux-store" "7.112.0"
+    "@frontegg/types" "7.112.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.111.0":
-  version "7.111.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.111.0.tgz#eb1acc6941ab94abd99802ba021a793185daa38b"
-  integrity sha512-OEdiong8II+CVfBDfObecO5G2Qb6rEOCnsKULHdFS4tOKrVTPo7EkQn1zE6xZMbaYolugzfpD8wbv1Kk7dnu9A==
+"@frontegg/redux-store@7.112.0":
+  version "7.112.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.112.0.tgz#623992069735a4fee82ba916a29a2731f8ba529f"
+  integrity sha512-FV9UDVHac6GCiBygdGRScsdEqftXMaLxKlJiBswGAhHBGlnCdC7G/8kK/6BmCYEUYbU4t5XbAc+rUyBarsPnDA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.111.0"
+    "@frontegg/rest-api" "7.112.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.111.0":
-  version "7.111.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.111.0.tgz#fdc645698b5f6c9844d0eec44d82cba95d19a22e"
-  integrity sha512-iHoDj+bvfdeUl62HM3q92wrFjyemopVhgykxPu//KTfCJJf+eZAdFuoLV4DOKnT7VRKa0oj5pDMACnB3UuuDfA==
+"@frontegg/rest-api@7.112.0":
+  version "7.112.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.112.0.tgz#dbb305895a0e9d6c23208667413c2888b48fcd93"
+  integrity sha512-0xC/oRUde3bbMl0zmTKn/3+hZHAtWm48aglybN2FiUd0I7XeIvzZYsQLCKs5xPWz79kxc5VhIWY8JB9sEMLFvw==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.111.0":
-  version "7.111.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.111.0.tgz#fc1d0715db85e7bf42c0ccad34f738a51f509717"
-  integrity sha512-06iGx5uNKEtVwHwkaI0LU8WASbYI1wvhl7dLv49WXSDAYM/CQCpzkUr9sIPJFZt/d93pL3Max/KGjUkynwEMNQ==
+"@frontegg/types@7.112.0":
+  version "7.112.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.112.0.tgz#8e20e68077eec17a39fd23e46c8b162af33de1ed"
+  integrity sha512-Uhl+Pu0iUutHFG5hCWxeN6vqoll8abxNsFFWh14BExZ0aI50AMAbc6VsxpMDDKRXevxvqlSiVfUuVAgtn1XGyw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.111.0"
+    "@frontegg/redux-store" "7.112.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.104.0":
-  version "7.104.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.104.0.tgz#fcdd6a5d3cd4af24604ee57e5f618935d92191ba"
-  integrity sha512-OeR6lQGSQ3MiUCOYhyqnbZ3aKyQL2U0gKr6CQOP7iecHioAHWCYL04ew/0HGiHOCga9uEIYEhS81n7OOQaW04w==
+"@frontegg/js@7.105.0":
+  version "7.105.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.105.0.tgz#0bc161ae0bd114dfea329060652960a1a9484ed2"
+  integrity sha512-qeY9PHQyUcpnEqcJvRkA0bnURZITSyzIEt4s8wrAzt11D0BlcwupAW1LNUxB7FzZYF50U9i+VDSTE7bnU1HbEQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.104.0"
+    "@frontegg/types" "7.105.0"
 
-"@frontegg/react-hooks@7.104.0":
-  version "7.104.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.104.0.tgz#b4375ec173b638990634c2d3bad367331678e7a0"
-  integrity sha512-l0yj9b4fADks0rz10teLh6tqVk5MtmIz2ocNCZtFQ2Olk3DuqxlUqo88FcdCtQ/Kp5ref5qXnmGoisTuMEd7Fg==
+"@frontegg/react-hooks@7.105.0":
+  version "7.105.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.105.0.tgz#a9e0916b7abe394b033300f6f8d7cd07ce490bf2"
+  integrity sha512-En7vcJlLrd25pG4YYkncLkUO/iaiBrwWNRbQ4cJz4a4Xbt4xFj9jem0140e8Fm/eh3b8AAtTynC8SNhdV1V1Tw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.104.0"
-    "@frontegg/types" "7.104.0"
+    "@frontegg/redux-store" "7.105.0"
+    "@frontegg/types" "7.105.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.104.0":
-  version "7.104.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.104.0.tgz#765d9b22ec3ef0905b6502d754bac1d5f7903e78"
-  integrity sha512-QYHo7b8hQ5sOlPGmMCM9WBfN8kG/i5kbGGeXswSOqPCuj5PM9Q3Sv5NtOHHL6VeFwbCyq78vBTVRRG0tYeEP5Q==
+"@frontegg/redux-store@7.105.0":
+  version "7.105.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.105.0.tgz#270da43dd6a57626371f23189b61f542ed569efe"
+  integrity sha512-+0YZjLYFItW/YEdYbIPKQQF7qCOIIRIwep6XAXvQMper0wwkv4PHOTcEpJrVy7lFC9WcJNYGqf6eBoKLfj6bFg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.104.0"
+    "@frontegg/rest-api" "7.105.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.104.0":
-  version "7.104.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.104.0.tgz#38cd79d885ca97290750a8d239d89aa55ec771a2"
-  integrity sha512-2xjBgHxOrFsJ9+4XYlHGFxOiwUExCy6ATUcBq9jJnED8gRkgTIETjSRVuMdG7LmrTwODME+t4aMyEul0WWhYxw==
+"@frontegg/rest-api@7.105.0":
+  version "7.105.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.105.0.tgz#f6e5bfd2555272ffcd9b6603fa2a7f7b6baa1528"
+  integrity sha512-LQJduI+7V5jRSBi9C5sbyuSjp8KcBU4loMaTO3PuXSBEm9bjEAju4EO/oqrTOEhP1gHKORGfRRkhMM9LkSW4WQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.104.0":
-  version "7.104.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.104.0.tgz#fe6ebc8b66f1259ec4057fcaa5388d76d14f3f6e"
-  integrity sha512-GPxfdP3s+4fcQc5UYdikV+wQGpvRBJK3g83GFZwTfhfSWWCMISQrr4wBtXDF1Yv19G6SRU6MZlnOI+cj84jafg==
+"@frontegg/types@7.105.0":
+  version "7.105.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.105.0.tgz#96bf991f7efa06621583c1f19dbc071d0d6f7f29"
+  integrity sha512-3SXrUw2ifmJ2c3qNQbiTe0GWIxNF1Dg8BMbs8RisfEkMennNq5o8EU4c3ISbizRrfIZZIDeek30Jqb949DsF3A==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.104.0"
+    "@frontegg/redux-store" "7.105.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.106.0":
-  version "7.106.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.106.0.tgz#83dcb57ce1463c8930b55ef03c9814b1996618e6"
-  integrity sha512-68TUOiG6xl5N9IXGmhDOeV0jKWwN9tQqPc98nI3OxHbZyPPOYxWINOTpj24W4wb81nU4pCZ8ffuGneL76QKbkQ==
+"@frontegg/js@7.107.0":
+  version "7.107.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.107.0.tgz#d88260b61dfa5263841f873c168d04fc82a7f49f"
+  integrity sha512-0QoVHi7Msvo2qhxBfebYt22KUGr8g+fwypx0/A3cbfLpwj60nuO1CxDz4FJWMiUG3a6gcG0cnMH5GM0lmVlANQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.106.0"
+    "@frontegg/types" "7.107.0"
 
-"@frontegg/react-hooks@7.106.0":
-  version "7.106.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.106.0.tgz#54ea1d834df9961c97d4b24fff5d282aa06076f8"
-  integrity sha512-zT1UNz1cJwVG0dD1T4ocRgum7TZf6gRqqrb2KBXl4vHN8+PUMlgXs/ouDfCWwvba/Qe3psq/mZ7XrNi8K6dvzA==
+"@frontegg/react-hooks@7.107.0":
+  version "7.107.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.107.0.tgz#56e5cff6b8a3ad3558364ea638f2f1cf0f7602db"
+  integrity sha512-4pkhL31DxDzEGfFpweOBkKltgr26kP5ETSBdStzOOtkKCDRTka7QstwKF7HUkRJWIZDobSY0yAdP8+TgzFMZpw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.106.0"
-    "@frontegg/types" "7.106.0"
+    "@frontegg/redux-store" "7.107.0"
+    "@frontegg/types" "7.107.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.106.0":
-  version "7.106.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.106.0.tgz#4cf6e36ac939bd88b1e2147f19b523b83011b89a"
-  integrity sha512-H4QXJEPkQd2t505C92FanfjAW12kPIZsaal+tgReJQqEixQUL8wbXZoe9pp48s9qUgaKoUd1F+dQ0AkdFulO8A==
+"@frontegg/redux-store@7.107.0":
+  version "7.107.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.107.0.tgz#1df08e7366ebe95c1ad66c1f894f4c28c54ca642"
+  integrity sha512-OqYQTsnYf8VrGdD3eXnYNwYdwvsGesdoLTVmATU3urOEMZn1hubEtgH102Tbr3u1h2/Q3GXUZmhgjQV8K8Z4wg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.106.0"
+    "@frontegg/rest-api" "7.107.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.106.0":
-  version "7.106.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.106.0.tgz#779d18b9e5d59e4301197bf165219eb2c7d6290e"
-  integrity sha512-a28vI8oFIFJPeFqrLw+Q9aJxCyoWaB1eOGzV5j7F/M8Q+zko4ac3AMXCTf1MfWyrMKk71L5DLoSX8f5z6B0xhA==
+"@frontegg/rest-api@7.107.0":
+  version "7.107.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.107.0.tgz#67fa90c6b2b7d8f272992177cb0f18a2987821c1"
+  integrity sha512-pRbfU7y8K2s1X16Eknlh/6mMiH31mLsMCZtEa8rVZrRQ/ZSVKaW9UZxNh+lttT90ZykTixN9KY2+3mxi6uOTFQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.106.0":
-  version "7.106.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.106.0.tgz#1c59f8b36fb80b33eab84fa6ad076815d4a499ed"
-  integrity sha512-emVdoZKQZ4Am3VYeF93BYC+qkzcxbWWBdtk3LKxwzBfzk6Fo7aLHNV3ThWZf2igNU+z5aK0fMyoM4Kiijb6eYw==
+"@frontegg/types@7.107.0":
+  version "7.107.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.107.0.tgz#ef9aca80c1c9b9edf563d9b909c5166263f4609a"
+  integrity sha512-GKGChl1HfcHMBoYli3/zDGf93e3M5HUno7pCV1vs5umOOBz8O4jtYsRlmtyCPduaLAUrvzxDS2pQrqfs8DwLHQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.106.0"
+    "@frontegg/redux-store" "7.107.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.102.0":
-  version "7.102.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.102.0.tgz#df984daba79ea485115567e55fb304e244a39cc4"
-  integrity sha512-zuOBw5g0YydUYJZpRCM3rr4W0m8HwyuqL04Bs7GuTA6aKqFZIEus5/F1uOhyLgR13ibWWH77UelLjp4IfKyzUQ==
+"@frontegg/js@7.103.0":
+  version "7.103.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.103.0.tgz#66b576e0d864737a7a86fb75d65ba2f4419e615e"
+  integrity sha512-jGh6mvFOlIZ30aWFQIjIegrZwryXzayX82445Q3zO2I6Zb0mMTaABuv6CycDS1Vyyqg1ruOxolvGuSrdFll1ww==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.102.0"
+    "@frontegg/types" "7.103.0"
 
-"@frontegg/react-hooks@7.102.0":
-  version "7.102.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.102.0.tgz#9c014675b0b2b54af8f8d6d30ca8922db896b401"
-  integrity sha512-Ff7ZDsdhLLmE1HWOz6GRzZhJ/xVYFkpNlGTMWiE1d9E4HcCC5gvqd2NKy4hsOuQn/r4eaMB10j1StfxW8WYvJg==
+"@frontegg/react-hooks@7.103.0":
+  version "7.103.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.103.0.tgz#ce6c53f162b3105098e58defbde45f1f9af0bd30"
+  integrity sha512-JixphHsgUup7nknU4CQB2gdta3Dr0fENRVmIufexmD3cwp8dnNk2z3HIgf9F9BRrK+b6XKG3E26z3Q+L6r333A==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.102.0"
-    "@frontegg/types" "7.102.0"
+    "@frontegg/redux-store" "7.103.0"
+    "@frontegg/types" "7.103.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.102.0":
-  version "7.102.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.102.0.tgz#013192952564d8fd28cfde2cffd5af323b538148"
-  integrity sha512-CdvtKo+JcdeZvJ6/34PCUMtz95Sh30mypcomiU3uYnjJ3PTv3XVfAj/wmhIAQh1MC1FoV5mx6GOs5/SzoXoDpg==
+"@frontegg/redux-store@7.103.0":
+  version "7.103.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.103.0.tgz#dcac3682692ed0ade339c15dc37f628cab784207"
+  integrity sha512-lxBW2rdbHgEWr1Y9wguzXWZuCaG4wwHVZJA5EsDzt3x8H/UJXZJGW0/3QPydWjfQ+twrGR9IM/fy3kAKpo5reg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.102.0"
+    "@frontegg/rest-api" "7.103.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.102.0":
-  version "7.102.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.102.0.tgz#3c4883ce513a6b0825ff6cf420818821f4cc854b"
-  integrity sha512-mLUzzskjhYZ6bZgy6x2PxnoLgGIu2wa8VbpJufGnWtIgIPrkdub6/OGQVaSsPyRzhdL3/vbSgAPpK5GL8dMqWQ==
+"@frontegg/rest-api@7.103.0":
+  version "7.103.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.103.0.tgz#35fb8ac94ec64854abbce9ce71317112d9eb03a6"
+  integrity sha512-Dm9l3LZSgR8kSGcErToeme2Uy3rl3nwTw82PzljepBQjZQmRr9VMcLArUQfKEcWMX9om4xXtPrqKfzS9GPc7Yw==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.102.0":
-  version "7.102.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.102.0.tgz#9269d634cf0de5194cef9ff99b98f153117e2cdf"
-  integrity sha512-KUI/iP3v3um+AY3apBEFklv9uc2x0XNMnyR9bQkvcwGW0Ia+jcUH508gskXYj5W2UxU9QGiXG2tnRFTq8ytHKQ==
+"@frontegg/types@7.103.0":
+  version "7.103.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.103.0.tgz#3abc05c15f7cf1bcb08994e2d1a555d5033e0302"
+  integrity sha512-LYhYv8T06iKHWxq3Nr9R0fmjzQIBTVmfmEveNRSvt+LcWaaSmECr5WFyR6vBNZ6SK+25PjGsB83NQmm+v8Litw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.102.0"
+    "@frontegg/redux-store" "7.103.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.105.0":
-  version "7.105.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.105.0.tgz#0bc161ae0bd114dfea329060652960a1a9484ed2"
-  integrity sha512-qeY9PHQyUcpnEqcJvRkA0bnURZITSyzIEt4s8wrAzt11D0BlcwupAW1LNUxB7FzZYF50U9i+VDSTE7bnU1HbEQ==
+"@frontegg/js@7.106.0":
+  version "7.106.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.106.0.tgz#83dcb57ce1463c8930b55ef03c9814b1996618e6"
+  integrity sha512-68TUOiG6xl5N9IXGmhDOeV0jKWwN9tQqPc98nI3OxHbZyPPOYxWINOTpj24W4wb81nU4pCZ8ffuGneL76QKbkQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.105.0"
+    "@frontegg/types" "7.106.0"
 
-"@frontegg/react-hooks@7.105.0":
-  version "7.105.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.105.0.tgz#a9e0916b7abe394b033300f6f8d7cd07ce490bf2"
-  integrity sha512-En7vcJlLrd25pG4YYkncLkUO/iaiBrwWNRbQ4cJz4a4Xbt4xFj9jem0140e8Fm/eh3b8AAtTynC8SNhdV1V1Tw==
+"@frontegg/react-hooks@7.106.0":
+  version "7.106.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.106.0.tgz#54ea1d834df9961c97d4b24fff5d282aa06076f8"
+  integrity sha512-zT1UNz1cJwVG0dD1T4ocRgum7TZf6gRqqrb2KBXl4vHN8+PUMlgXs/ouDfCWwvba/Qe3psq/mZ7XrNi8K6dvzA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.105.0"
-    "@frontegg/types" "7.105.0"
+    "@frontegg/redux-store" "7.106.0"
+    "@frontegg/types" "7.106.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.105.0":
-  version "7.105.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.105.0.tgz#270da43dd6a57626371f23189b61f542ed569efe"
-  integrity sha512-+0YZjLYFItW/YEdYbIPKQQF7qCOIIRIwep6XAXvQMper0wwkv4PHOTcEpJrVy7lFC9WcJNYGqf6eBoKLfj6bFg==
+"@frontegg/redux-store@7.106.0":
+  version "7.106.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.106.0.tgz#4cf6e36ac939bd88b1e2147f19b523b83011b89a"
+  integrity sha512-H4QXJEPkQd2t505C92FanfjAW12kPIZsaal+tgReJQqEixQUL8wbXZoe9pp48s9qUgaKoUd1F+dQ0AkdFulO8A==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.105.0"
+    "@frontegg/rest-api" "7.106.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.105.0":
-  version "7.105.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.105.0.tgz#f6e5bfd2555272ffcd9b6603fa2a7f7b6baa1528"
-  integrity sha512-LQJduI+7V5jRSBi9C5sbyuSjp8KcBU4loMaTO3PuXSBEm9bjEAju4EO/oqrTOEhP1gHKORGfRRkhMM9LkSW4WQ==
+"@frontegg/rest-api@7.106.0":
+  version "7.106.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.106.0.tgz#779d18b9e5d59e4301197bf165219eb2c7d6290e"
+  integrity sha512-a28vI8oFIFJPeFqrLw+Q9aJxCyoWaB1eOGzV5j7F/M8Q+zko4ac3AMXCTf1MfWyrMKk71L5DLoSX8f5z6B0xhA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.105.0":
-  version "7.105.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.105.0.tgz#96bf991f7efa06621583c1f19dbc071d0d6f7f29"
-  integrity sha512-3SXrUw2ifmJ2c3qNQbiTe0GWIxNF1Dg8BMbs8RisfEkMennNq5o8EU4c3ISbizRrfIZZIDeek30Jqb949DsF3A==
+"@frontegg/types@7.106.0":
+  version "7.106.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.106.0.tgz#1c59f8b36fb80b33eab84fa6ad076815d4a499ed"
+  integrity sha512-emVdoZKQZ4Am3VYeF93BYC+qkzcxbWWBdtk3LKxwzBfzk6Fo7aLHNV3ThWZf2igNU+z5aK0fMyoM4Kiijb6eYw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.105.0"
+    "@frontegg/redux-store" "7.106.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.113.0":
-  version "7.113.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.113.0.tgz#204a18d336b69e9f1efc31c08511d51a0cc2b064"
-  integrity sha512-u+JW4WDDk6Kv8b3B+rjDy/XMawYQ7dIjCn/Xr+BeM1oiNoFQnLjC+iBNG+BpJPAO60Sahb/ilrUkd1bO36jSDw==
+"@frontegg/js@7.114.0":
+  version "7.114.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.114.0.tgz#8f6bab2c7542f6ff2d806877096807cd3e818865"
+  integrity sha512-eX5bQbOe+Kj9/nWBCi+zfnqdtembPWmESdcnfixzvnbLRe4IdcI3CQO1FKwWd9G+U5Vs7T2gVimAvrM2PuZwkQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.113.0"
+    "@frontegg/types" "7.114.0"
 
-"@frontegg/react-hooks@7.113.0":
-  version "7.113.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.113.0.tgz#af9b68b86d3639e3f06ebd096bbfa8a12418f4a6"
-  integrity sha512-b3CB0Q3KQjzQwhKabm66ip6cuWDopOIWmtl9eU1nGYR74u550rw+bzqiZNOu9bC9O1kPqutKvzdItqjBmwoNjA==
+"@frontegg/react-hooks@7.114.0":
+  version "7.114.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.114.0.tgz#e5bf040858e4f0540f039f8189045d5091ad210f"
+  integrity sha512-JeT9MWHYxQPaSZKn+nJqAXyQlIosYRP3uaySHWBvDW1YCvVJUpwjv6KjRt/xW07BEn0oRUx1EM1+mCr3dM2xTQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.113.0"
-    "@frontegg/types" "7.113.0"
+    "@frontegg/redux-store" "7.114.0"
+    "@frontegg/types" "7.114.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.113.0":
-  version "7.113.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.113.0.tgz#5f8587eaa35cf8f075e8f3bd60e107dae2bb0edb"
-  integrity sha512-NjmzBwK9T7OtI6rF1ZOlwuFwttHUb5QxCZaPq23McEtV7wNiIbMvWQpstnK0/WEV2odjWjYLrJO0n9PK4bpDcg==
+"@frontegg/redux-store@7.114.0":
+  version "7.114.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.114.0.tgz#8c3316527736419ab0d0096ce86236f6293f715c"
+  integrity sha512-VZ0rtw1Qz6Fe5ZjTndRCoy1RLKcu7OYl6AJ0OJFoItBedXxbgk1Wtx3v+3q+fYo6t57xJMAMhEJJdn3fgjYvWg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.113.0"
+    "@frontegg/rest-api" "7.114.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.113.0":
-  version "7.113.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.113.0.tgz#f363cff59444cf2ad3022a0e2c051677e9037f43"
-  integrity sha512-3F1aerS8NUhiSyMoadcAz5NGY3W1dZNLuWFUYrlpHlUcMsrHHHAq8vuMsTZoKzxOGXuWH02zmEGqoLBijfOWIQ==
+"@frontegg/rest-api@7.114.0":
+  version "7.114.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.114.0.tgz#b7fea8f367fb3b768f230d2dac8aab2e22faf5c9"
+  integrity sha512-3HlLyPaj1XG9rySafW+q2/Q5XOinxuJn8Qsrk93IFZgC6pTn3rNEi0Pftv7ihStOYS1D9LesgVj43NnOWXAP3Q==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.113.0":
-  version "7.113.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.113.0.tgz#f5185721d7b301eef8d9a894b31b79344e497851"
-  integrity sha512-Mqp/nS4rM1WP5tg7cV355ajsMB7NMHe9kgrJHUZUf/MIye6IGhjLWx0zV/POfnS4/bJ82P4mxHIxlVEgnTiaKw==
+"@frontegg/types@7.114.0":
+  version "7.114.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.114.0.tgz#021f3a746549b47f28c5e33272b9a7416c472e6d"
+  integrity sha512-4JSJOQoWcWpCJAkRlw0eLuy0qi0LiwRu2KF687Y8NjO78S+D6K4ldwcnueo0EK4+kR723oT42TVKpQzC8Hz+MQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.113.0"
+    "@frontegg/redux-store" "7.114.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.109.0":
-  version "7.109.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.109.0.tgz#b1ac6dab705b0ded3ca44196e4cec48a482f92bd"
-  integrity sha512-hgtOjCxRcvoLtw9avlP5bLSFXoB5h59BOdcBk1wJt96EMODrcbvmn8h6CxwoeTA92aAxDr0iGjbFzgdk7ob5JA==
+"@frontegg/js@7.110.0":
+  version "7.110.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.110.0.tgz#1f54937abd539074d7e2c986bf840b9ec7c37dc0"
+  integrity sha512-pjxCQrrrQp+qaiWAbRg9BF/0z4xUk69WoIO14S9gEQjtctez90SjuW2Ah7ndYnX1jDiL69Usm1HeP8bT/fNEFQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.109.0"
+    "@frontegg/types" "7.110.0"
 
-"@frontegg/react-hooks@7.109.0":
-  version "7.109.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.109.0.tgz#66c4c1dd5362886d330a75add21e7a376bd6202e"
-  integrity sha512-I1mVwADICaqZY5Hs2HPCLbDZdIHtZ8y7IPZJjmw++CI7y4QUX1dlFL5toFuD+9ui+R9/y0YR8HZbawP/Fd11fg==
+"@frontegg/react-hooks@7.110.0":
+  version "7.110.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.110.0.tgz#10112eb5e898ea8f75ad9003456c9d1cfbea3b66"
+  integrity sha512-wa2Aue9ep7vOmWYpy6aA1JcZrODdg4APgmHpuHP07sQs1Z3CLQoDeByKcQ5aPtL5aeLHI7yR+yiF04PXTdJ4kg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.109.0"
-    "@frontegg/types" "7.109.0"
+    "@frontegg/redux-store" "7.110.0"
+    "@frontegg/types" "7.110.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.109.0":
-  version "7.109.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.109.0.tgz#f694f1f4da4151422b4f363cebff9300f65928dc"
-  integrity sha512-65Wdi4LCp5rhUTJ4IzH16G/CsAplEXPFUFPiP4YBAxG2XfW9uxVI5lzILAuzdGxTka5BlDXY1RWJdpSWzolLQA==
+"@frontegg/redux-store@7.110.0":
+  version "7.110.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.110.0.tgz#b4a453fcf16eb44183b0242768b841eb5d4e0a19"
+  integrity sha512-eyX+G1yxls2XAubra1IB2rJvt17a2fk90fyv76/X8cK6WfamVItfvoVc0w6D0+QWKmQ0c0oCFCIDuyVIeK86Og==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.109.0"
+    "@frontegg/rest-api" "7.110.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.109.0":
-  version "7.109.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.109.0.tgz#3362b2a981009d7b02507a8dd8ae01298942984b"
-  integrity sha512-CAgYoZq1CvkRqdvhSajFmz4Rq61OukVBK+paop5rDOGtadUQahLr3U9DPws70lr/WlFJVo6JteZ0HSXIUkVSvQ==
+"@frontegg/rest-api@7.110.0":
+  version "7.110.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.110.0.tgz#44645a7af8c9547e3de54157819d712ac862a306"
+  integrity sha512-sip50EJ6bJfvcXW9j+kt8xNRCNeSEnCNworJ7QHZQzS80pO0RAWTwn9to0yHlLxcSWBvE6JytAPAwnsDn48bYg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.109.0":
-  version "7.109.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.109.0.tgz#1ba5c191b18dd3ce4b71e4577da8286d74dc08e6"
-  integrity sha512-jmebSltxheTxGsSejwUEeWkiAW8POLYcE+TzlpSAaH7MdFyCUK4+xjOlnOnWyDm3Wz4S73gIl/yoyyDc3Rcylw==
+"@frontegg/types@7.110.0":
+  version "7.110.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.110.0.tgz#2314bb43b5d31be4c9ab7be52adaf20f6d68b31c"
+  integrity sha512-Jzybo6foUBZh4k3CsN2r/AKoaF2V0EANq/3EyvMqT+3vnVtlYX2RPsmERuxK4ddKXzppuYHKxCXjK88Hn8voJg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.109.0"
+    "@frontegg/redux-store" "7.110.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.108.0":
-  version "7.108.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.108.0.tgz#ae6f2f8304811de103105ba3b127a7514c9907d1"
-  integrity sha512-hxFc/lGfu3nPBy+J39O/j5JTwy9kq7XcyhXKNm5BqaU6+Sz2edYrWzvz/GrYWLRgEW2mBwTGndlJlLfNk5mbWQ==
+"@frontegg/js@7.109.0":
+  version "7.109.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.109.0.tgz#b1ac6dab705b0ded3ca44196e4cec48a482f92bd"
+  integrity sha512-hgtOjCxRcvoLtw9avlP5bLSFXoB5h59BOdcBk1wJt96EMODrcbvmn8h6CxwoeTA92aAxDr0iGjbFzgdk7ob5JA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.108.0"
+    "@frontegg/types" "7.109.0"
 
-"@frontegg/react-hooks@7.108.0":
-  version "7.108.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.108.0.tgz#ec850b467ac1ceab9c7c763c4b060f227a1792fc"
-  integrity sha512-/y48Wb4U8qN0LP84YmZR33o/Qj0qIkSJZYr+p8wY4GuxpMnGfk0EgDomHYhx1idr+Q5lRcy5G1eReGtjNMSTxw==
+"@frontegg/react-hooks@7.109.0":
+  version "7.109.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.109.0.tgz#66c4c1dd5362886d330a75add21e7a376bd6202e"
+  integrity sha512-I1mVwADICaqZY5Hs2HPCLbDZdIHtZ8y7IPZJjmw++CI7y4QUX1dlFL5toFuD+9ui+R9/y0YR8HZbawP/Fd11fg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.108.0"
-    "@frontegg/types" "7.108.0"
+    "@frontegg/redux-store" "7.109.0"
+    "@frontegg/types" "7.109.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.108.0":
-  version "7.108.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.108.0.tgz#b006117dd71e952dd750f432ac70bf477bab7d38"
-  integrity sha512-UhFTTK0KPhqeHEjpm34/WJ+MSFYPI91aaHdfYZEnVIGy9J/IJQVQVN+T9UHTNVAenXKWaHisONvcRDT8nJyrEQ==
+"@frontegg/redux-store@7.109.0":
+  version "7.109.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.109.0.tgz#f694f1f4da4151422b4f363cebff9300f65928dc"
+  integrity sha512-65Wdi4LCp5rhUTJ4IzH16G/CsAplEXPFUFPiP4YBAxG2XfW9uxVI5lzILAuzdGxTka5BlDXY1RWJdpSWzolLQA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.108.0"
+    "@frontegg/rest-api" "7.109.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.108.0":
-  version "7.108.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.108.0.tgz#d8e04e4be4103624dae981c9ea327c0436371666"
-  integrity sha512-WGS45/5glGPz0x7ySF6kLPOVb03RGt1XRpWsKtrJ6RPCuqF9MHlKgx/o6l1rFWL/Z9JwBNNU/bF3PovLhgAjSA==
+"@frontegg/rest-api@7.109.0":
+  version "7.109.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.109.0.tgz#3362b2a981009d7b02507a8dd8ae01298942984b"
+  integrity sha512-CAgYoZq1CvkRqdvhSajFmz4Rq61OukVBK+paop5rDOGtadUQahLr3U9DPws70lr/WlFJVo6JteZ0HSXIUkVSvQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.108.0":
-  version "7.108.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.108.0.tgz#3247c38be85ca3e75a5c40633cf2db2ac2f644f4"
-  integrity sha512-3ruThcwU4/bsy3P1+RbARepope0+JBhL/B506TbTHFUD30wRC725njh8uvu23MRnOZtohNdgCKJkuKX8X1c/aA==
+"@frontegg/types@7.109.0":
+  version "7.109.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.109.0.tgz#1ba5c191b18dd3ce4b71e4577da8286d74dc08e6"
+  integrity sha512-jmebSltxheTxGsSejwUEeWkiAW8POLYcE+TzlpSAaH7MdFyCUK4+xjOlnOnWyDm3Wz4S73gIl/yoyyDc3Rcylw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.108.0"
+    "@frontegg/redux-store" "7.109.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.107.0":
-  version "7.107.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.107.0.tgz#d88260b61dfa5263841f873c168d04fc82a7f49f"
-  integrity sha512-0QoVHi7Msvo2qhxBfebYt22KUGr8g+fwypx0/A3cbfLpwj60nuO1CxDz4FJWMiUG3a6gcG0cnMH5GM0lmVlANQ==
+"@frontegg/js@7.108.0":
+  version "7.108.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.108.0.tgz#ae6f2f8304811de103105ba3b127a7514c9907d1"
+  integrity sha512-hxFc/lGfu3nPBy+J39O/j5JTwy9kq7XcyhXKNm5BqaU6+Sz2edYrWzvz/GrYWLRgEW2mBwTGndlJlLfNk5mbWQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.107.0"
+    "@frontegg/types" "7.108.0"
 
-"@frontegg/react-hooks@7.107.0":
-  version "7.107.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.107.0.tgz#56e5cff6b8a3ad3558364ea638f2f1cf0f7602db"
-  integrity sha512-4pkhL31DxDzEGfFpweOBkKltgr26kP5ETSBdStzOOtkKCDRTka7QstwKF7HUkRJWIZDobSY0yAdP8+TgzFMZpw==
+"@frontegg/react-hooks@7.108.0":
+  version "7.108.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.108.0.tgz#ec850b467ac1ceab9c7c763c4b060f227a1792fc"
+  integrity sha512-/y48Wb4U8qN0LP84YmZR33o/Qj0qIkSJZYr+p8wY4GuxpMnGfk0EgDomHYhx1idr+Q5lRcy5G1eReGtjNMSTxw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.107.0"
-    "@frontegg/types" "7.107.0"
+    "@frontegg/redux-store" "7.108.0"
+    "@frontegg/types" "7.108.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.107.0":
-  version "7.107.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.107.0.tgz#1df08e7366ebe95c1ad66c1f894f4c28c54ca642"
-  integrity sha512-OqYQTsnYf8VrGdD3eXnYNwYdwvsGesdoLTVmATU3urOEMZn1hubEtgH102Tbr3u1h2/Q3GXUZmhgjQV8K8Z4wg==
+"@frontegg/redux-store@7.108.0":
+  version "7.108.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.108.0.tgz#b006117dd71e952dd750f432ac70bf477bab7d38"
+  integrity sha512-UhFTTK0KPhqeHEjpm34/WJ+MSFYPI91aaHdfYZEnVIGy9J/IJQVQVN+T9UHTNVAenXKWaHisONvcRDT8nJyrEQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.107.0"
+    "@frontegg/rest-api" "7.108.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.107.0":
-  version "7.107.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.107.0.tgz#67fa90c6b2b7d8f272992177cb0f18a2987821c1"
-  integrity sha512-pRbfU7y8K2s1X16Eknlh/6mMiH31mLsMCZtEa8rVZrRQ/ZSVKaW9UZxNh+lttT90ZykTixN9KY2+3mxi6uOTFQ==
+"@frontegg/rest-api@7.108.0":
+  version "7.108.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.108.0.tgz#d8e04e4be4103624dae981c9ea327c0436371666"
+  integrity sha512-WGS45/5glGPz0x7ySF6kLPOVb03RGt1XRpWsKtrJ6RPCuqF9MHlKgx/o6l1rFWL/Z9JwBNNU/bF3PovLhgAjSA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.107.0":
-  version "7.107.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.107.0.tgz#ef9aca80c1c9b9edf563d9b909c5166263f4609a"
-  integrity sha512-GKGChl1HfcHMBoYli3/zDGf93e3M5HUno7pCV1vs5umOOBz8O4jtYsRlmtyCPduaLAUrvzxDS2pQrqfs8DwLHQ==
+"@frontegg/types@7.108.0":
+  version "7.108.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.108.0.tgz#3247c38be85ca3e75a5c40633cf2db2ac2f644f4"
+  integrity sha512-3ruThcwU4/bsy3P1+RbARepope0+JBhL/B506TbTHFUD30wRC725njh8uvu23MRnOZtohNdgCKJkuKX8X1c/aA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.107.0"
+    "@frontegg/redux-store" "7.108.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.115.0":
-  version "7.115.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.115.0.tgz#47e143fb18e3342fb21c83999108970c5560bc5c"
-  integrity sha512-07dxt0Lq3c3B1MHh4R1MJmJ9E0PhPdaXIcQUvXGOvxTWupOTo/Yn4FJEvlZKqf1YjZcLiKM2hOCCzd7GFjINXg==
+"@frontegg/js@7.116.0":
+  version "7.116.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.116.0.tgz#0b15380ead744f99a3dd84721c649d0f7f59e4d8"
+  integrity sha512-XSJvtvxI9gBmBJ+F0ZJdF/UqiSJXOuaSy4IAy2vFfM9rsAeeKYOQY0XXwris2RvMs4sr5N2ZrjoexUsm7H5AEw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.115.0"
+    "@frontegg/types" "7.116.0"
 
-"@frontegg/react-hooks@7.115.0":
-  version "7.115.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.115.0.tgz#f157397e7c703f8a70aff1426a4a780a2f8c7425"
-  integrity sha512-nVU5CThj2AiylqUoBn3RUrZngRZ7MlKbyHSG0T+y2V5zPPbdXEI6y8iEkYQaPg78JSQpHSj0T44ItwciIv67mA==
+"@frontegg/react-hooks@7.116.0":
+  version "7.116.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.116.0.tgz#2f145a0fc45310524208358fbe69a4c6a30239b2"
+  integrity sha512-1ynbHVTwmzEVw9r/uC3rH+lMITRcEtQNOnAIxuL7sIX7MT9mYyx81R29E+iaHhCv6XnxEtthQgdRdQxkAV34hg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.115.0"
-    "@frontegg/types" "7.115.0"
+    "@frontegg/redux-store" "7.116.0"
+    "@frontegg/types" "7.116.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.115.0":
-  version "7.115.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.115.0.tgz#2f016ad28e196ee1725fe6f7983817231ae3f69f"
-  integrity sha512-1yaCLaQI4bG8b2doy++wA0IEuFHWokfeO6Xg/NHTj0sRIMbyQDusiUeYLsNHw99pwHdAQJGEjy+71zcS3UX/vQ==
+"@frontegg/redux-store@7.116.0":
+  version "7.116.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.116.0.tgz#73aa8e3554411775d1b0a7a0e64a13cedeac5491"
+  integrity sha512-a1cy8OxWQY6RgFUNQspfYVN7xCZYAYx+MbOXM7jiz+jnbyGARmP8s3YPypb+CE1B6PVttWLXiLkn2ClATVUKxA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.115.0"
+    "@frontegg/rest-api" "7.116.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.115.0":
-  version "7.115.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.115.0.tgz#9c2e0e3ee695e61211281bb5db6950baa0b5e3b4"
-  integrity sha512-EsXmjQjox6/zxNXZ375xM/P6V4R1fpyfTJ79ikwCc6N8CpR0OuBODSSlgKooZHnch1fnFnBNx+hoS5XWDpwrIA==
+"@frontegg/rest-api@7.116.0":
+  version "7.116.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.116.0.tgz#945c6361de4301a624912ed06c0c78307ea4bf3e"
+  integrity sha512-rsFTq0i/PmVVCQ2EU3rCVrBBkY9LVDSUQ20G4Fp4SZrBobUTQvntyHbMFlUfK4Yeb6dTY4iZFM8IOzmqJv+21g==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.115.0":
-  version "7.115.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.115.0.tgz#1b63d62159dc1b613d2553c6e722b3bb8060c1cf"
-  integrity sha512-nGNQjlQ2TtvqEwc1XUI3FUz8cCRmNH2OT2BjFTdUxWrL27zyD41L74bujdgMvqGTLrgXVraFoAFykmnJIf6/kw==
+"@frontegg/types@7.116.0":
+  version "7.116.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.116.0.tgz#47e2e3dd36d9436b0614cbea9baa4acde12ac770"
+  integrity sha512-GzDEqgq0s/D/i3HP4WyIujf41QixPrveBjv3QRb8sjCjAN6GFetKjporEl0Dukydi5fmxw1ExScHn6SrQJgnBA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.115.0"
+    "@frontegg/redux-store" "7.116.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.116.0":
-  version "7.116.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.116.0.tgz#0b15380ead744f99a3dd84721c649d0f7f59e4d8"
-  integrity sha512-XSJvtvxI9gBmBJ+F0ZJdF/UqiSJXOuaSy4IAy2vFfM9rsAeeKYOQY0XXwris2RvMs4sr5N2ZrjoexUsm7H5AEw==
+"@frontegg/js@7.117.0":
+  version "7.117.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.117.0.tgz#042e0b9e61588211450fc9c8928693b54b53d487"
+  integrity sha512-nnB9Y7B8D2uDKX0z+YpN7JyhBpjwXitVECzs2XaUaNPWykL5D17vReK1TBZBl9D1IBuY6tfgXRQ+Hz7V5/cXhQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.116.0"
+    "@frontegg/types" "7.117.0"
 
-"@frontegg/react-hooks@7.116.0":
-  version "7.116.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.116.0.tgz#2f145a0fc45310524208358fbe69a4c6a30239b2"
-  integrity sha512-1ynbHVTwmzEVw9r/uC3rH+lMITRcEtQNOnAIxuL7sIX7MT9mYyx81R29E+iaHhCv6XnxEtthQgdRdQxkAV34hg==
+"@frontegg/react-hooks@7.117.0":
+  version "7.117.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.117.0.tgz#92dca9daaa61244265ff86625cce0ab7a94d5253"
+  integrity sha512-NjlwC7lHTtKtLvKjOwMoAnswnBHXz6et1dH8GkMjbTFeoaSr+A6ADEmnp3ndC10WgiPYhlLVNB0YtqqnI8emSg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.116.0"
-    "@frontegg/types" "7.116.0"
+    "@frontegg/redux-store" "7.117.0"
+    "@frontegg/types" "7.117.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.116.0":
-  version "7.116.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.116.0.tgz#73aa8e3554411775d1b0a7a0e64a13cedeac5491"
-  integrity sha512-a1cy8OxWQY6RgFUNQspfYVN7xCZYAYx+MbOXM7jiz+jnbyGARmP8s3YPypb+CE1B6PVttWLXiLkn2ClATVUKxA==
+"@frontegg/redux-store@7.117.0":
+  version "7.117.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.117.0.tgz#0e7e98b21b36623fc7b2d4009146cb8d01151e44"
+  integrity sha512-uJImfp5Yx/QF8ml79Uv9QjAtufXDKx0iS/y5a694dY6ycrTiSB4pfNvPb3htVLk2sIIpssk9Jt06PuflfgzAcA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.116.0"
+    "@frontegg/rest-api" "7.117.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.116.0":
-  version "7.116.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.116.0.tgz#945c6361de4301a624912ed06c0c78307ea4bf3e"
-  integrity sha512-rsFTq0i/PmVVCQ2EU3rCVrBBkY9LVDSUQ20G4Fp4SZrBobUTQvntyHbMFlUfK4Yeb6dTY4iZFM8IOzmqJv+21g==
+"@frontegg/rest-api@7.117.0":
+  version "7.117.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.117.0.tgz#dbbede10c18dd65dd74e7e2302cf1b687b5e2a13"
+  integrity sha512-kPs83HLvb8Z4/gf9wGeEH34AOIb2l9Ayv+WhK3QpwSvNBd02hTHhAYyW4ACAi/87Nd3cFSXnlejB/8lA3oEtfg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.116.0":
-  version "7.116.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.116.0.tgz#47e2e3dd36d9436b0614cbea9baa4acde12ac770"
-  integrity sha512-GzDEqgq0s/D/i3HP4WyIujf41QixPrveBjv3QRb8sjCjAN6GFetKjporEl0Dukydi5fmxw1ExScHn6SrQJgnBA==
+"@frontegg/types@7.117.0":
+  version "7.117.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.117.0.tgz#4e2b467cb4652add472c38406dcd54908bd27028"
+  integrity sha512-89UhOnzXld3pxPmkdePIko0fleSYQbvK28xh0Ym5cZAG/MsqAIGPgpHVA/T0+U2LwoEu+WJVmjrB1wASSzJg+g==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.116.0"
+    "@frontegg/redux-store" "7.117.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.103.0":
-  version "7.103.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.103.0.tgz#66b576e0d864737a7a86fb75d65ba2f4419e615e"
-  integrity sha512-jGh6mvFOlIZ30aWFQIjIegrZwryXzayX82445Q3zO2I6Zb0mMTaABuv6CycDS1Vyyqg1ruOxolvGuSrdFll1ww==
+"@frontegg/js@7.104.0":
+  version "7.104.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.104.0.tgz#fcdd6a5d3cd4af24604ee57e5f618935d92191ba"
+  integrity sha512-OeR6lQGSQ3MiUCOYhyqnbZ3aKyQL2U0gKr6CQOP7iecHioAHWCYL04ew/0HGiHOCga9uEIYEhS81n7OOQaW04w==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.103.0"
+    "@frontegg/types" "7.104.0"
 
-"@frontegg/react-hooks@7.103.0":
-  version "7.103.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.103.0.tgz#ce6c53f162b3105098e58defbde45f1f9af0bd30"
-  integrity sha512-JixphHsgUup7nknU4CQB2gdta3Dr0fENRVmIufexmD3cwp8dnNk2z3HIgf9F9BRrK+b6XKG3E26z3Q+L6r333A==
+"@frontegg/react-hooks@7.104.0":
+  version "7.104.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.104.0.tgz#b4375ec173b638990634c2d3bad367331678e7a0"
+  integrity sha512-l0yj9b4fADks0rz10teLh6tqVk5MtmIz2ocNCZtFQ2Olk3DuqxlUqo88FcdCtQ/Kp5ref5qXnmGoisTuMEd7Fg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.103.0"
-    "@frontegg/types" "7.103.0"
+    "@frontegg/redux-store" "7.104.0"
+    "@frontegg/types" "7.104.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.103.0":
-  version "7.103.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.103.0.tgz#dcac3682692ed0ade339c15dc37f628cab784207"
-  integrity sha512-lxBW2rdbHgEWr1Y9wguzXWZuCaG4wwHVZJA5EsDzt3x8H/UJXZJGW0/3QPydWjfQ+twrGR9IM/fy3kAKpo5reg==
+"@frontegg/redux-store@7.104.0":
+  version "7.104.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.104.0.tgz#765d9b22ec3ef0905b6502d754bac1d5f7903e78"
+  integrity sha512-QYHo7b8hQ5sOlPGmMCM9WBfN8kG/i5kbGGeXswSOqPCuj5PM9Q3Sv5NtOHHL6VeFwbCyq78vBTVRRG0tYeEP5Q==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.103.0"
+    "@frontegg/rest-api" "7.104.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.103.0":
-  version "7.103.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.103.0.tgz#35fb8ac94ec64854abbce9ce71317112d9eb03a6"
-  integrity sha512-Dm9l3LZSgR8kSGcErToeme2Uy3rl3nwTw82PzljepBQjZQmRr9VMcLArUQfKEcWMX9om4xXtPrqKfzS9GPc7Yw==
+"@frontegg/rest-api@7.104.0":
+  version "7.104.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.104.0.tgz#38cd79d885ca97290750a8d239d89aa55ec771a2"
+  integrity sha512-2xjBgHxOrFsJ9+4XYlHGFxOiwUExCy6ATUcBq9jJnED8gRkgTIETjSRVuMdG7LmrTwODME+t4aMyEul0WWhYxw==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.103.0":
-  version "7.103.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.103.0.tgz#3abc05c15f7cf1bcb08994e2d1a555d5033e0302"
-  integrity sha512-LYhYv8T06iKHWxq3Nr9R0fmjzQIBTVmfmEveNRSvt+LcWaaSmECr5WFyR6vBNZ6SK+25PjGsB83NQmm+v8Litw==
+"@frontegg/types@7.104.0":
+  version "7.104.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.104.0.tgz#fe6ebc8b66f1259ec4057fcaa5388d76d14f3f6e"
+  integrity sha512-GPxfdP3s+4fcQc5UYdikV+wQGpvRBJK3g83GFZwTfhfSWWCMISQrr4wBtXDF1Yv19G6SRU6MZlnOI+cj84jafg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.103.0"
+    "@frontegg/redux-store" "7.104.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.117.0":
-  version "7.117.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.117.0.tgz#042e0b9e61588211450fc9c8928693b54b53d487"
-  integrity sha512-nnB9Y7B8D2uDKX0z+YpN7JyhBpjwXitVECzs2XaUaNPWykL5D17vReK1TBZBl9D1IBuY6tfgXRQ+Hz7V5/cXhQ==
+"@frontegg/js@7.118.0":
+  version "7.118.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.118.0.tgz#96120eb736bf1b16b851a7d02116b1e1adcc45c2"
+  integrity sha512-IPQ+68ZkcBGtND61W/6Y5tkqawWKFWYYDHZq7+OV00dyBvUO4xxo25MnLRExmdKHqPCANDi+3NtDx062AglSGA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.117.0"
+    "@frontegg/types" "7.118.0"
 
-"@frontegg/react-hooks@7.117.0":
-  version "7.117.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.117.0.tgz#92dca9daaa61244265ff86625cce0ab7a94d5253"
-  integrity sha512-NjlwC7lHTtKtLvKjOwMoAnswnBHXz6et1dH8GkMjbTFeoaSr+A6ADEmnp3ndC10WgiPYhlLVNB0YtqqnI8emSg==
+"@frontegg/react-hooks@7.118.0":
+  version "7.118.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.118.0.tgz#e5a20efdf2cfbcfb4400fbe6231fa52de7989184"
+  integrity sha512-tA+S5/MiEWOpYWG8/jzORmq1a9dqX79rzYgXoV3pfy24+seP+QpCwkKhHSdBd5SFvEC799v+Db3xxwKFZ9b4aQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.117.0"
-    "@frontegg/types" "7.117.0"
+    "@frontegg/redux-store" "7.118.0"
+    "@frontegg/types" "7.118.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.117.0":
-  version "7.117.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.117.0.tgz#0e7e98b21b36623fc7b2d4009146cb8d01151e44"
-  integrity sha512-uJImfp5Yx/QF8ml79Uv9QjAtufXDKx0iS/y5a694dY6ycrTiSB4pfNvPb3htVLk2sIIpssk9Jt06PuflfgzAcA==
+"@frontegg/redux-store@7.118.0":
+  version "7.118.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.118.0.tgz#394f7d7765060fb8bb4be60abd4ce79a75c32a6a"
+  integrity sha512-XrET52gdXo65b3qf3UozXPvjawgoDjZZ6HD36so2ximlPpyRBwHG3h2iRtjNML/QdaCbTH8NnGYVuinwKPA+0A==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.117.0"
+    "@frontegg/rest-api" "7.118.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.117.0":
-  version "7.117.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.117.0.tgz#dbbede10c18dd65dd74e7e2302cf1b687b5e2a13"
-  integrity sha512-kPs83HLvb8Z4/gf9wGeEH34AOIb2l9Ayv+WhK3QpwSvNBd02hTHhAYyW4ACAi/87Nd3cFSXnlejB/8lA3oEtfg==
+"@frontegg/rest-api@7.118.0":
+  version "7.118.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.118.0.tgz#c1fbf6cb76ba3033942afa8d63879ee237954433"
+  integrity sha512-kjVZKV5yRZQPwua2Xw+HYxmPIg/NujNYPCo325oiGBffxVWvlDyaIVAofjtVfohHaQlEpcluOcBD7juc6m7xIg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.117.0":
-  version "7.117.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.117.0.tgz#4e2b467cb4652add472c38406dcd54908bd27028"
-  integrity sha512-89UhOnzXld3pxPmkdePIko0fleSYQbvK28xh0Ym5cZAG/MsqAIGPgpHVA/T0+U2LwoEu+WJVmjrB1wASSzJg+g==
+"@frontegg/types@7.118.0":
+  version "7.118.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.118.0.tgz#0fbeb6bcf1e9494c3e99bd454eef716e5d98d2f8"
+  integrity sha512-atiJTJaoD3wiCYpeByyGyy72uL8l2rKoQmBI1q1g4JOETzQLpZPj05mbKlLHmoPJMhL0XYd1u3jhMIopWI1H+w==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.117.0"
+    "@frontegg/redux-store" "7.118.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.114.0":
-  version "7.114.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.114.0.tgz#8f6bab2c7542f6ff2d806877096807cd3e818865"
-  integrity sha512-eX5bQbOe+Kj9/nWBCi+zfnqdtembPWmESdcnfixzvnbLRe4IdcI3CQO1FKwWd9G+U5Vs7T2gVimAvrM2PuZwkQ==
+"@frontegg/js@7.115.0":
+  version "7.115.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.115.0.tgz#47e143fb18e3342fb21c83999108970c5560bc5c"
+  integrity sha512-07dxt0Lq3c3B1MHh4R1MJmJ9E0PhPdaXIcQUvXGOvxTWupOTo/Yn4FJEvlZKqf1YjZcLiKM2hOCCzd7GFjINXg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.114.0"
+    "@frontegg/types" "7.115.0"
 
-"@frontegg/react-hooks@7.114.0":
-  version "7.114.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.114.0.tgz#e5bf040858e4f0540f039f8189045d5091ad210f"
-  integrity sha512-JeT9MWHYxQPaSZKn+nJqAXyQlIosYRP3uaySHWBvDW1YCvVJUpwjv6KjRt/xW07BEn0oRUx1EM1+mCr3dM2xTQ==
+"@frontegg/react-hooks@7.115.0":
+  version "7.115.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.115.0.tgz#f157397e7c703f8a70aff1426a4a780a2f8c7425"
+  integrity sha512-nVU5CThj2AiylqUoBn3RUrZngRZ7MlKbyHSG0T+y2V5zPPbdXEI6y8iEkYQaPg78JSQpHSj0T44ItwciIv67mA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.114.0"
-    "@frontegg/types" "7.114.0"
+    "@frontegg/redux-store" "7.115.0"
+    "@frontegg/types" "7.115.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.114.0":
-  version "7.114.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.114.0.tgz#8c3316527736419ab0d0096ce86236f6293f715c"
-  integrity sha512-VZ0rtw1Qz6Fe5ZjTndRCoy1RLKcu7OYl6AJ0OJFoItBedXxbgk1Wtx3v+3q+fYo6t57xJMAMhEJJdn3fgjYvWg==
+"@frontegg/redux-store@7.115.0":
+  version "7.115.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.115.0.tgz#2f016ad28e196ee1725fe6f7983817231ae3f69f"
+  integrity sha512-1yaCLaQI4bG8b2doy++wA0IEuFHWokfeO6Xg/NHTj0sRIMbyQDusiUeYLsNHw99pwHdAQJGEjy+71zcS3UX/vQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.114.0"
+    "@frontegg/rest-api" "7.115.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.114.0":
-  version "7.114.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.114.0.tgz#b7fea8f367fb3b768f230d2dac8aab2e22faf5c9"
-  integrity sha512-3HlLyPaj1XG9rySafW+q2/Q5XOinxuJn8Qsrk93IFZgC6pTn3rNEi0Pftv7ihStOYS1D9LesgVj43NnOWXAP3Q==
+"@frontegg/rest-api@7.115.0":
+  version "7.115.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.115.0.tgz#9c2e0e3ee695e61211281bb5db6950baa0b5e3b4"
+  integrity sha512-EsXmjQjox6/zxNXZ375xM/P6V4R1fpyfTJ79ikwCc6N8CpR0OuBODSSlgKooZHnch1fnFnBNx+hoS5XWDpwrIA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.114.0":
-  version "7.114.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.114.0.tgz#021f3a746549b47f28c5e33272b9a7416c472e6d"
-  integrity sha512-4JSJOQoWcWpCJAkRlw0eLuy0qi0LiwRu2KF687Y8NjO78S+D6K4ldwcnueo0EK4+kR723oT42TVKpQzC8Hz+MQ==
+"@frontegg/types@7.115.0":
+  version "7.115.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.115.0.tgz#1b63d62159dc1b613d2553c6e722b3bb8060c1cf"
+  integrity sha512-nGNQjlQ2TtvqEwc1XUI3FUz8cCRmNH2OT2BjFTdUxWrL27zyD41L74bujdgMvqGTLrgXVraFoAFykmnJIf6/kw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.114.0"
+    "@frontegg/redux-store" "7.115.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.112.0":
-  version "7.112.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.112.0.tgz#183503ebbd89b334a37dcf65749d59941ef30120"
-  integrity sha512-RSKi5vg8fBePLl1bD7MrsKIt4QVHpUKl1p98Bf2lh9vZtCwK6ZNucnF/oeLio0HGUUY8ciCZJEJgX/RW7quwCw==
+"@frontegg/js@7.113.0":
+  version "7.113.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.113.0.tgz#204a18d336b69e9f1efc31c08511d51a0cc2b064"
+  integrity sha512-u+JW4WDDk6Kv8b3B+rjDy/XMawYQ7dIjCn/Xr+BeM1oiNoFQnLjC+iBNG+BpJPAO60Sahb/ilrUkd1bO36jSDw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.112.0"
+    "@frontegg/types" "7.113.0"
 
-"@frontegg/react-hooks@7.112.0":
-  version "7.112.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.112.0.tgz#f0be20c6f9c281952dc0bb8c08405ec057b2a781"
-  integrity sha512-Pu0NMByLBv4+bY0IwR9QFd6q87OW8moFo6VbHRWzzM1ISM3XUyxCj9nd8nvq7ffwMpKO/uyZL0rQYFXsKp/Fxg==
+"@frontegg/react-hooks@7.113.0":
+  version "7.113.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.113.0.tgz#af9b68b86d3639e3f06ebd096bbfa8a12418f4a6"
+  integrity sha512-b3CB0Q3KQjzQwhKabm66ip6cuWDopOIWmtl9eU1nGYR74u550rw+bzqiZNOu9bC9O1kPqutKvzdItqjBmwoNjA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.112.0"
-    "@frontegg/types" "7.112.0"
+    "@frontegg/redux-store" "7.113.0"
+    "@frontegg/types" "7.113.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.112.0":
-  version "7.112.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.112.0.tgz#623992069735a4fee82ba916a29a2731f8ba529f"
-  integrity sha512-FV9UDVHac6GCiBygdGRScsdEqftXMaLxKlJiBswGAhHBGlnCdC7G/8kK/6BmCYEUYbU4t5XbAc+rUyBarsPnDA==
+"@frontegg/redux-store@7.113.0":
+  version "7.113.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.113.0.tgz#5f8587eaa35cf8f075e8f3bd60e107dae2bb0edb"
+  integrity sha512-NjmzBwK9T7OtI6rF1ZOlwuFwttHUb5QxCZaPq23McEtV7wNiIbMvWQpstnK0/WEV2odjWjYLrJO0n9PK4bpDcg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.112.0"
+    "@frontegg/rest-api" "7.113.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.112.0":
-  version "7.112.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.112.0.tgz#dbb305895a0e9d6c23208667413c2888b48fcd93"
-  integrity sha512-0xC/oRUde3bbMl0zmTKn/3+hZHAtWm48aglybN2FiUd0I7XeIvzZYsQLCKs5xPWz79kxc5VhIWY8JB9sEMLFvw==
+"@frontegg/rest-api@7.113.0":
+  version "7.113.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.113.0.tgz#f363cff59444cf2ad3022a0e2c051677e9037f43"
+  integrity sha512-3F1aerS8NUhiSyMoadcAz5NGY3W1dZNLuWFUYrlpHlUcMsrHHHAq8vuMsTZoKzxOGXuWH02zmEGqoLBijfOWIQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.112.0":
-  version "7.112.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.112.0.tgz#8e20e68077eec17a39fd23e46c8b162af33de1ed"
-  integrity sha512-Uhl+Pu0iUutHFG5hCWxeN6vqoll8abxNsFFWh14BExZ0aI50AMAbc6VsxpMDDKRXevxvqlSiVfUuVAgtn1XGyw==
+"@frontegg/types@7.113.0":
+  version "7.113.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.113.0.tgz#f5185721d7b301eef8d9a894b31b79344e497851"
+  integrity sha512-Mqp/nS4rM1WP5tg7cV355ajsMB7NMHe9kgrJHUZUf/MIye6IGhjLWx0zV/POfnS4/bJ82P4mxHIxlVEgnTiaKw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.112.0"
+    "@frontegg/redux-store" "7.113.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.110.0":
-  version "7.110.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.110.0.tgz#1f54937abd539074d7e2c986bf840b9ec7c37dc0"
-  integrity sha512-pjxCQrrrQp+qaiWAbRg9BF/0z4xUk69WoIO14S9gEQjtctez90SjuW2Ah7ndYnX1jDiL69Usm1HeP8bT/fNEFQ==
+"@frontegg/js@7.111.0":
+  version "7.111.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.111.0.tgz#ab06b82501a072751e0fd964c39d423fab8558c1"
+  integrity sha512-pDNJLykhVNwO9smFbWTjNKOtO2XOhLrTwYelC0Hah0cC/BNtZyogV8SoGOy5CP0ni1DFGBGJjjZNxRaZT8YwQw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.110.0"
+    "@frontegg/types" "7.111.0"
 
-"@frontegg/react-hooks@7.110.0":
-  version "7.110.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.110.0.tgz#10112eb5e898ea8f75ad9003456c9d1cfbea3b66"
-  integrity sha512-wa2Aue9ep7vOmWYpy6aA1JcZrODdg4APgmHpuHP07sQs1Z3CLQoDeByKcQ5aPtL5aeLHI7yR+yiF04PXTdJ4kg==
+"@frontegg/react-hooks@7.111.0":
+  version "7.111.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.111.0.tgz#d37c0badede0d726cb1d6f15d3882ca0f7b45bed"
+  integrity sha512-F4cbPGhqpH5KeFNMXuf9D1ChW/fSLPFEdIBv4Eu30GwVlI82MFb3yFHPMMXcK4QXYB5bn98VEGW4fuusKv8VKQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.110.0"
-    "@frontegg/types" "7.110.0"
+    "@frontegg/redux-store" "7.111.0"
+    "@frontegg/types" "7.111.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.110.0":
-  version "7.110.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.110.0.tgz#b4a453fcf16eb44183b0242768b841eb5d4e0a19"
-  integrity sha512-eyX+G1yxls2XAubra1IB2rJvt17a2fk90fyv76/X8cK6WfamVItfvoVc0w6D0+QWKmQ0c0oCFCIDuyVIeK86Og==
+"@frontegg/redux-store@7.111.0":
+  version "7.111.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.111.0.tgz#eb1acc6941ab94abd99802ba021a793185daa38b"
+  integrity sha512-OEdiong8II+CVfBDfObecO5G2Qb6rEOCnsKULHdFS4tOKrVTPo7EkQn1zE6xZMbaYolugzfpD8wbv1Kk7dnu9A==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.110.0"
+    "@frontegg/rest-api" "7.111.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.110.0":
-  version "7.110.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.110.0.tgz#44645a7af8c9547e3de54157819d712ac862a306"
-  integrity sha512-sip50EJ6bJfvcXW9j+kt8xNRCNeSEnCNworJ7QHZQzS80pO0RAWTwn9to0yHlLxcSWBvE6JytAPAwnsDn48bYg==
+"@frontegg/rest-api@7.111.0":
+  version "7.111.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.111.0.tgz#fdc645698b5f6c9844d0eec44d82cba95d19a22e"
+  integrity sha512-iHoDj+bvfdeUl62HM3q92wrFjyemopVhgykxPu//KTfCJJf+eZAdFuoLV4DOKnT7VRKa0oj5pDMACnB3UuuDfA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.110.0":
-  version "7.110.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.110.0.tgz#2314bb43b5d31be4c9ab7be52adaf20f6d68b31c"
-  integrity sha512-Jzybo6foUBZh4k3CsN2r/AKoaF2V0EANq/3EyvMqT+3vnVtlYX2RPsmERuxK4ddKXzppuYHKxCXjK88Hn8voJg==
+"@frontegg/types@7.111.0":
+  version "7.111.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.111.0.tgz#fc1d0715db85e7bf42c0ccad34f738a51f509717"
+  integrity sha512-06iGx5uNKEtVwHwkaI0LU8WASbYI1wvhl7dLv49WXSDAYM/CQCpzkUr9sIPJFZt/d93pL3Max/KGjUkynwEMNQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.110.0"
+    "@frontegg/redux-store" "7.111.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.118.0":
-  version "7.118.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.118.0.tgz#96120eb736bf1b16b851a7d02116b1e1adcc45c2"
-  integrity sha512-IPQ+68ZkcBGtND61W/6Y5tkqawWKFWYYDHZq7+OV00dyBvUO4xxo25MnLRExmdKHqPCANDi+3NtDx062AglSGA==
+"@frontegg/js@7.119.0":
+  version "7.119.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.119.0.tgz#6b9df0f41390a9b2ac8ef3dbedc3d46fae8a3b80"
+  integrity sha512-U4A0Gz57G/trMHZpOf8tG94LLbsc0A+DbZmBJ4eMQFM+zS/4UKgc3k0V0QdeID3D4nPr8T+RuqqueOOHVlFBdg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.118.0"
+    "@frontegg/types" "7.119.0"
 
-"@frontegg/react-hooks@7.118.0":
-  version "7.118.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.118.0.tgz#e5a20efdf2cfbcfb4400fbe6231fa52de7989184"
-  integrity sha512-tA+S5/MiEWOpYWG8/jzORmq1a9dqX79rzYgXoV3pfy24+seP+QpCwkKhHSdBd5SFvEC799v+Db3xxwKFZ9b4aQ==
+"@frontegg/react-hooks@7.119.0":
+  version "7.119.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.119.0.tgz#ac3f5433cdeeaeabbfe912e24c1433b946d4671f"
+  integrity sha512-ji1jzk7muyLoVH/l9brdqXpNa5FUGVEojHVfM1kQ/VYYvt2zKviUpmYdyXZAWxsheCTEF2sumpJMTGhhxAROWQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.118.0"
-    "@frontegg/types" "7.118.0"
+    "@frontegg/redux-store" "7.119.0"
+    "@frontegg/types" "7.119.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.118.0":
-  version "7.118.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.118.0.tgz#394f7d7765060fb8bb4be60abd4ce79a75c32a6a"
-  integrity sha512-XrET52gdXo65b3qf3UozXPvjawgoDjZZ6HD36so2ximlPpyRBwHG3h2iRtjNML/QdaCbTH8NnGYVuinwKPA+0A==
+"@frontegg/redux-store@7.119.0":
+  version "7.119.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.119.0.tgz#e932dab1cc046242ac70d81d5afe64f863aba045"
+  integrity sha512-TKdkfdqiV6x7IjmwNfhUEpmCYLuLLshR1bTdZdIaEMr+4PjTKnN+qIEX8Gb/Dy9eVJCHIC4/pFegQBK+s655Gg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.118.0"
+    "@frontegg/rest-api" "7.119.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.118.0":
-  version "7.118.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.118.0.tgz#c1fbf6cb76ba3033942afa8d63879ee237954433"
-  integrity sha512-kjVZKV5yRZQPwua2Xw+HYxmPIg/NujNYPCo325oiGBffxVWvlDyaIVAofjtVfohHaQlEpcluOcBD7juc6m7xIg==
+"@frontegg/rest-api@7.119.0":
+  version "7.119.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.119.0.tgz#2ab4e1a769ac9b1c08f25d09396140ac903a2a3d"
+  integrity sha512-Tm2fmbRGNHWJT4SAr0cKdOWxgqFPMx9RsMxpgNtkDiFEdAUrusoDYKogJsm9YVQcXFuJnYuBTNfpCClPXDx5jg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.118.0":
-  version "7.118.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.118.0.tgz#0fbeb6bcf1e9494c3e99bd454eef716e5d98d2f8"
-  integrity sha512-atiJTJaoD3wiCYpeByyGyy72uL8l2rKoQmBI1q1g4JOETzQLpZPj05mbKlLHmoPJMhL0XYd1u3jhMIopWI1H+w==
+"@frontegg/types@7.119.0":
+  version "7.119.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.119.0.tgz#ec62cf7e13687ff25cab848f6c489ab0bd7fd863"
+  integrity sha512-hye2AFyd+X2svUNCYBc1WjnrnwXyQOtMfxOJpApEKlTy9uwrD0u1DcNxQE0iEzf3tYFosqeD46FOzsmhZeHeeg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.118.0"
+    "@frontegg/redux-store" "7.119.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.121.0":
-  version "7.121.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.121.0.tgz#6f689b5e593e1a5af429f31ebac7cc160056ee3f"
-  integrity sha512-1b3iatasy2KmjxQb1MBeVu2YDt1rDOyfZU1XOGhpILNVCPBAx0ikR1FpilaeAIeDfnWUzmCW5djO2Vf39LPAFQ==
+"@frontegg/js@7.122.0":
+  version "7.122.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.122.0.tgz#344faf28c851a4b82ffe338102b38f176457d542"
+  integrity sha512-k73xedmLo5ANiz1uttnObM2nB+l2kr6ihogD8XWRhvJqmqiUQjztiUrFgBk91oox43wJ/CYUDHbqTDGcKAZhmw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.121.0"
+    "@frontegg/types" "7.122.0"
 
-"@frontegg/react-hooks@7.121.0":
-  version "7.121.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.121.0.tgz#b4754c1616c1092c5a8e721579371d8d05051c09"
-  integrity sha512-CiogfneiJNReJEUXrXHeLd5CGFEQ+FUZ/ApqlJBmnnMbWk5UpG3Syw/PJG6jg8ZBf3Cq6ccNYl2uPCrAV/jpEA==
+"@frontegg/react-hooks@7.122.0":
+  version "7.122.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.122.0.tgz#8c7194e3aac68c5922559ddd5e1b3f37f03d4243"
+  integrity sha512-NzEefL5E5VXvlUe68UZwNTWN0N9O6MszqbuE+JiCtlJv00hH9dV/PAbvJqpea3nVyufpXQxzfVTdDEFOhge0QQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.121.0"
-    "@frontegg/types" "7.121.0"
+    "@frontegg/redux-store" "7.122.0"
+    "@frontegg/types" "7.122.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.121.0":
-  version "7.121.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.121.0.tgz#5b7c5ffebb72c6bafc82e66eec84489313d125e8"
-  integrity sha512-veuogq/+FytB4QJrLaXGmoGKK8qXAlbYwEP8YEN6F3pk3IRlOSw6IUcgfJjUBBCnteWd7RSsUaN53F+EBOPdSg==
+"@frontegg/redux-store@7.122.0":
+  version "7.122.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.122.0.tgz#fc0083cc8eca1b7575ad6684b9bf90cf6d0a40cf"
+  integrity sha512-B6mxuY8Qi9S0CccUqdY3LUc5bcUcY3KtgKNXpU3LAu59tKYeAMSOML3YMX6TABqD5+lLW9lrsTwprWLjLeJFqw==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.121.0"
+    "@frontegg/rest-api" "7.122.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.121.0":
-  version "7.121.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.121.0.tgz#d1cd44a73d3e7383933e36679b8ce58ea09d9e70"
-  integrity sha512-0hyqdFocy7nToQSIOpZXycSesQQeudAhHzJE16Qh529iVYfAQkhhagbyH397OtwsEHsQ7GUlOrq7SEe+GrDP9w==
+"@frontegg/rest-api@7.122.0":
+  version "7.122.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.122.0.tgz#e1322e428515ea4151b65a6ec501d57468ab50f6"
+  integrity sha512-QUBJQpq8lHW91DGi8boQawLbVs5KV53245Nlg/aE6nN5pafHACc2waO/Vq74t6dzsJ8ppIsGTDAb0xDIwK2+dQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.121.0":
-  version "7.121.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.121.0.tgz#e5d1fd00c4b2e2342a935417a075c8192bff35c9"
-  integrity sha512-uYswZ8MIZYXcB1anFdDucV+RQ4W5OCgUwuia85pbFWfnIz6iNxK3+++VSSYzd/m0UItMLtWhyUVyYpgbhshONA==
+"@frontegg/types@7.122.0":
+  version "7.122.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.122.0.tgz#869c2ca561343be781525d041b047f1ba412d3c7"
+  integrity sha512-lPf454g2V6KXorLzjR/ZFgRJmbMWeBBRcLkJ/DNoDGvigR+PF51GqgjgCuOuOXu2qUVGREjmCV/mpmjmJhF5zA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.121.0"
+    "@frontegg/redux-store" "7.122.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.119.0":
-  version "7.119.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.119.0.tgz#6b9df0f41390a9b2ac8ef3dbedc3d46fae8a3b80"
-  integrity sha512-U4A0Gz57G/trMHZpOf8tG94LLbsc0A+DbZmBJ4eMQFM+zS/4UKgc3k0V0QdeID3D4nPr8T+RuqqueOOHVlFBdg==
+"@frontegg/js@7.120.0":
+  version "7.120.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.120.0.tgz#724392aeb510d3701ebaa6e17b882b2c681f35e0"
+  integrity sha512-He9hxIBNelS6V9NhuGYS84rH2Vo/pMmMuBE88+qcNQvf6tL4FQA/gZ0jVp3A0fnw/UL7iqF8mffzE2ZQwS+l7Q==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.119.0"
+    "@frontegg/types" "7.120.0"
 
-"@frontegg/react-hooks@7.119.0":
-  version "7.119.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.119.0.tgz#ac3f5433cdeeaeabbfe912e24c1433b946d4671f"
-  integrity sha512-ji1jzk7muyLoVH/l9brdqXpNa5FUGVEojHVfM1kQ/VYYvt2zKviUpmYdyXZAWxsheCTEF2sumpJMTGhhxAROWQ==
+"@frontegg/react-hooks@7.120.0":
+  version "7.120.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.120.0.tgz#7925f9342de270a28eec9c566f8b8abef661ee6f"
+  integrity sha512-xO3Z7UEpNz+uq8zI2aEPenYVz18Yq9Xmbxoj+CPdBauu2O/e5dWg67EHmV3bf02+lL5xWlV/IXuH/JoEDCS/SA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.119.0"
-    "@frontegg/types" "7.119.0"
+    "@frontegg/redux-store" "7.120.0"
+    "@frontegg/types" "7.120.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.119.0":
-  version "7.119.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.119.0.tgz#e932dab1cc046242ac70d81d5afe64f863aba045"
-  integrity sha512-TKdkfdqiV6x7IjmwNfhUEpmCYLuLLshR1bTdZdIaEMr+4PjTKnN+qIEX8Gb/Dy9eVJCHIC4/pFegQBK+s655Gg==
+"@frontegg/redux-store@7.120.0":
+  version "7.120.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.120.0.tgz#cae4c1fb5bf8aac985d5ef6dbcac5a9bdb214c7b"
+  integrity sha512-kv8TiCYmPe9TZPGnXAa88sEIYYc2CfKBSylxiZH3vayezRxfdYb8vwJOMX/+z8zoEVnW/2PvfzAHNLB5vmsCWQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.119.0"
+    "@frontegg/rest-api" "7.120.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.119.0":
-  version "7.119.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.119.0.tgz#2ab4e1a769ac9b1c08f25d09396140ac903a2a3d"
-  integrity sha512-Tm2fmbRGNHWJT4SAr0cKdOWxgqFPMx9RsMxpgNtkDiFEdAUrusoDYKogJsm9YVQcXFuJnYuBTNfpCClPXDx5jg==
+"@frontegg/rest-api@7.120.0":
+  version "7.120.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.120.0.tgz#1cc000520dc430d84c96650a6bc7c7a522976ceb"
+  integrity sha512-EXOdZZmhs5HzwerInobCBfb/fPLdcjXyTJRqjT9WebDy8yYNanWeYWCXVVqgKWmQk0sfb0g6G80tY5QVUqAa+A==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.119.0":
-  version "7.119.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.119.0.tgz#ec62cf7e13687ff25cab848f6c489ab0bd7fd863"
-  integrity sha512-hye2AFyd+X2svUNCYBc1WjnrnwXyQOtMfxOJpApEKlTy9uwrD0u1DcNxQE0iEzf3tYFosqeD46FOzsmhZeHeeg==
+"@frontegg/types@7.120.0":
+  version "7.120.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.120.0.tgz#64094156bf70054b2023f35f680c7af1a21bc0d5"
+  integrity sha512-+JFl7jGzFbDsTTxPMvj/AvifWDXfIu0k8A3NDt2JavbCz0MnkmtLxmZhF3YJkTUesWslGiPnj3qHy1mYO8R//A==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.119.0"
+    "@frontegg/redux-store" "7.120.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,57 +1406,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.120.0":
-  version "7.120.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.120.0.tgz#724392aeb510d3701ebaa6e17b882b2c681f35e0"
-  integrity sha512-He9hxIBNelS6V9NhuGYS84rH2Vo/pMmMuBE88+qcNQvf6tL4FQA/gZ0jVp3A0fnw/UL7iqF8mffzE2ZQwS+l7Q==
+"@frontegg/js@7.121.0":
+  version "7.121.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.121.0.tgz#6f689b5e593e1a5af429f31ebac7cc160056ee3f"
+  integrity sha512-1b3iatasy2KmjxQb1MBeVu2YDt1rDOyfZU1XOGhpILNVCPBAx0ikR1FpilaeAIeDfnWUzmCW5djO2Vf39LPAFQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.120.0"
+    "@frontegg/types" "7.121.0"
 
-"@frontegg/react-hooks@7.120.0":
-  version "7.120.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.120.0.tgz#7925f9342de270a28eec9c566f8b8abef661ee6f"
-  integrity sha512-xO3Z7UEpNz+uq8zI2aEPenYVz18Yq9Xmbxoj+CPdBauu2O/e5dWg67EHmV3bf02+lL5xWlV/IXuH/JoEDCS/SA==
+"@frontegg/react-hooks@7.121.0":
+  version "7.121.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.121.0.tgz#b4754c1616c1092c5a8e721579371d8d05051c09"
+  integrity sha512-CiogfneiJNReJEUXrXHeLd5CGFEQ+FUZ/ApqlJBmnnMbWk5UpG3Syw/PJG6jg8ZBf3Cq6ccNYl2uPCrAV/jpEA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.120.0"
-    "@frontegg/types" "7.120.0"
+    "@frontegg/redux-store" "7.121.0"
+    "@frontegg/types" "7.121.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.120.0":
-  version "7.120.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.120.0.tgz#cae4c1fb5bf8aac985d5ef6dbcac5a9bdb214c7b"
-  integrity sha512-kv8TiCYmPe9TZPGnXAa88sEIYYc2CfKBSylxiZH3vayezRxfdYb8vwJOMX/+z8zoEVnW/2PvfzAHNLB5vmsCWQ==
+"@frontegg/redux-store@7.121.0":
+  version "7.121.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.121.0.tgz#5b7c5ffebb72c6bafc82e66eec84489313d125e8"
+  integrity sha512-veuogq/+FytB4QJrLaXGmoGKK8qXAlbYwEP8YEN6F3pk3IRlOSw6IUcgfJjUBBCnteWd7RSsUaN53F+EBOPdSg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.120.0"
+    "@frontegg/rest-api" "7.121.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.120.0":
-  version "7.120.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.120.0.tgz#1cc000520dc430d84c96650a6bc7c7a522976ceb"
-  integrity sha512-EXOdZZmhs5HzwerInobCBfb/fPLdcjXyTJRqjT9WebDy8yYNanWeYWCXVVqgKWmQk0sfb0g6G80tY5QVUqAa+A==
+"@frontegg/rest-api@7.121.0":
+  version "7.121.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.121.0.tgz#d1cd44a73d3e7383933e36679b8ce58ea09d9e70"
+  integrity sha512-0hyqdFocy7nToQSIOpZXycSesQQeudAhHzJE16Qh529iVYfAQkhhagbyH397OtwsEHsQ7GUlOrq7SEe+GrDP9w==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.120.0":
-  version "7.120.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.120.0.tgz#64094156bf70054b2023f35f680c7af1a21bc0d5"
-  integrity sha512-+JFl7jGzFbDsTTxPMvj/AvifWDXfIu0k8A3NDt2JavbCz0MnkmtLxmZhF3YJkTUesWslGiPnj3qHy1mYO8R//A==
+"@frontegg/types@7.121.0":
+  version "7.121.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.121.0.tgz#e5d1fd00c4b2e2342a935417a075c8192bff35c9"
+  integrity sha512-uYswZ8MIZYXcB1anFdDucV+RQ4W5OCgUwuia85pbFWfnIz6iNxK3+++VSSYzd/m0UItMLtWhyUVyYpgbhshONA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.120.0"
+    "@frontegg/redux-store" "7.121.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-24113 - Added mobile-friendly authenticator setup-key enrollment UI
- FR-24965 - Added remember last used MFA factor preference
- FR-26112 - Fixed iOS Password AutoFill on the embedded login page


- FR-25731 - Fixed chooser load-error state seeding when switchable list empties after opening


- FR-25731 - Added post-auth Choose Organization step in login-box (forward-port of #2864 to v7.120.x)


- FR-26014 - Added admin-box addressType redux branch (external instant-nav) [7.119.x]

- FR-24939 - Fixed native step-up challenge not rendering in the embedded login WebView
- FR-24853 - Removed identifiers flag

- FR-23757 - Fixed the actor of system audit logs to not be unknown

- FR-25580 - Fixed token refresh resilience with retry backoff

- FR-24939 - Fixed step-up gate ignoring max_age when the token has no auth_time
- FR-24939 - Fixed mobile SDK step-up looping to a blank&#x2F;error page instead of the MFA challenge


- FR-24988 - Fixed hosted login box accessibility issues
- FR-25494 - fixed stale frontegg oauth stale


- FR-24579 - Fixed admin-portal white screen in mobile SDK by refreshing session from native tokens

- FR-24579 - Fixed admin-portal redirect race on native auth handoff
- FR-24579 - Fixed admin-portal mobile bridge capability gating and stuck loading

- FR-24579 - Added native token bridge for the admin portal (no second login)
- FR-20973 - Fixed sso with username
- FR-20975 - Fixed description username login with magic code
- FR-22194 - Fixed error massage of username already exists missing from UI
- FR-20977 - Fixed resend with username in magic link


- FR-25111 - Fixed tenant regex


- FR-25022 - Changed phone validations


- FR-23507 - Fixed custom login box favicon not displaying pulls from main login box instead

- FR-24663 - Fixed country restriction dark theme input
- FR-24664 - Fixed country field background in modern theme
- FR-24693 - Fixed country restriction admin portal not full list of countries display for allow deny lists
- FR-24661 - Fixed country restriction tip counter updates
- FR-24667 - Added country restriction admin portal current country is not added to the list after enabling the counter restriction toggle


- FR-24187 - Fixed CPU issues


- FR-23435 - Added country restriction features to Security Center
- FR-23515 - Fixed wrong audit log tooltips
- FR-23524 - Added guidesCdnUrl to SSOPage


- FR-23900 - Added validation for reset password token and improved user feedback for expired links


- FR-23610 - Added login completed GTM
- FR-23421 - Added support for CMC SCIM guide dialog and fix SSO guide


- FR-22979 - Changed callback in InviteUserForm to handle errors and reset form state


- FR-22346 - Fixed enable session per tenant data mismatch between user jwt and sdk    
- FR-22346 - Fixed enable session per tenant data mismatch between user jwt and sdk    

- FR-23484 - Added an option to render SSO guides outside of admin box


- FR-22263 - Fixed publish

- FR-23141 - Added username edit config


- FR-17084 - Fixed loader

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency-only change, but the jump spans many auth, session, step-up, and mobile-bridge fixes in the Frontegg SDK, so login and admin flows should be regression-tested.
> 
> **Overview**
> Bumps **`@frontegg/nextjs`**’s pinned Frontegg SDK from **7.95.0** to **7.122.0** by updating **`@frontegg/js`** and **`@frontegg/react-hooks`** in `packages/nextjs/package.json`, with matching **`yarn.lock`** entries for the full `@frontegg/*` tree (`types`, `redux-store`, `rest-api`).
> 
> No application source in this repo is modified—integrators inherit upstream Admin Portal / login-box behavior from that release line (e.g. post-auth org chooser, token refresh backoff, mobile native token bridge, step-up/MFA fixes, country restriction in Security Center, and assorted login/SSO UI fixes per the PR notes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86dd1c8778dc04bfda4d3f9953e1ff964b2b4343. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->